### PR TITLE
Registry API to create modded registries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id "architectury-plugin" version "2.0.57"
-    id "forgified-fabric-loom" version "0.6.49" apply false
+    id "architectury-plugin" version "2.0.59"
+    id "forgified-fabric-loom" version "0.6.53" apply false
     id "org.cadixdev.licenser" version "0.5.0"
     id "com.jfrog.bintray" version "1.8.4"
     id "com.matthewprenger.cursegradle" version "1.4.0" apply false

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "architectury-plugin" version "2.0.63"
+    id "architectury-plugin" version "2.0.64"
     id "forgified-fabric-loom" version "0.6.53" apply false
     id "org.cadixdev.licenser" version "0.5.0"
     id "com.jfrog.bintray" version "1.8.4"

--- a/common/src/main/java/me/shedaniel/architectury/core/RegistryEntry.java
+++ b/common/src/main/java/me/shedaniel/architectury/core/RegistryEntry.java
@@ -19,11 +19,8 @@
 
 package me.shedaniel.architectury.core;
 
-import net.minecraft.world.item.crafting.Recipe;
-import net.minecraft.world.item.crafting.RecipeSerializer;
-
 /**
- * The equivalent of {@link RecipeSerializer} to use in common that has forge registry entries extended.
+ * An entry in registries, will extend {@code ForgeRegistryEntry} on forge.
  */
-public abstract class AbstractRecipeSerializer<T extends Recipe<?>> extends RegistryEntry<T> implements RecipeSerializer<T> {
+public class RegistryEntry<T> {
 }

--- a/common/src/main/java/me/shedaniel/architectury/event/events/client/ClientLifecycleEvent.java
+++ b/common/src/main/java/me/shedaniel/architectury/event/events/client/ClientLifecycleEvent.java
@@ -43,7 +43,6 @@ public interface ClientLifecycleEvent {
     Event<ClientWorldState> CLIENT_WORLD_LOAD = EventFactory.createLoop();
     Event<ClientState> CLIENT_SETUP = EventFactory.createLoop();
     
-    @Deprecated
     @Environment(EnvType.CLIENT)
     interface ClientState extends LifecycleEvent.InstanceState<Minecraft> {}
     

--- a/common/src/main/java/me/shedaniel/architectury/registry/Registries.java
+++ b/common/src/main/java/me/shedaniel/architectury/registry/Registries.java
@@ -20,9 +20,12 @@
 package me.shedaniel.architectury.registry;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+import me.shedaniel.architectury.core.RegistryEntry;
+import me.shedaniel.architectury.registry.registries.RegistryBuilder;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -36,6 +39,7 @@ public final class Registries {
     private final RegistryProvider provider;
     private final String modId;
     
+    @NotNull
     public static Registries get(String modId) {
         return REGISTRIES.computeIfAbsent(modId, Registries::new);
     }
@@ -45,13 +49,22 @@ public final class Registries {
         this.modId = modId;
     }
     
+    @NotNull
     public <T> Registry<T> get(ResourceKey<net.minecraft.core.Registry<T>> key) {
         return this.provider.get(key);
     }
     
+    @NotNull
     @Deprecated
     public <T> Registry<T> get(net.minecraft.core.Registry<T> registry) {
         return this.provider.get(registry);
+    }
+    
+    @NotNull
+    @SafeVarargs
+    public final <T extends RegistryEntry<T>> RegistryBuilder<T> builder(ResourceLocation registryId, T... typeGetter) {
+        if (typeGetter.length != 0) throw new IllegalStateException("array must be empty!");
+        return this.provider.builder((Class<T>) typeGetter.getClass().getComponentType(), registryId);
     }
     
     /**
@@ -79,8 +92,8 @@ public final class Registries {
      * Forge: If the object is {@code IForgeRegistryEntry}, use `getRegistryName`, else null
      * Fabric: null
      */
-    @Deprecated
     @Nullable
+    @Deprecated
     public static <T> ResourceLocation getRegistryName(T object) {
         return getId(object, (ResourceKey<net.minecraft.core.Registry<T>>) null);
     }
@@ -90,6 +103,7 @@ public final class Registries {
         throw new AssertionError();
     }
     
+    @NotNull
     public String getModId() {
         return modId;
     }
@@ -100,5 +114,7 @@ public final class Registries {
         
         @Deprecated
         <T> Registry<T> get(net.minecraft.core.Registry<T> registry);
+        
+        <T extends RegistryEntry<T>> RegistryBuilder<T> builder(Class<T> type, ResourceLocation registryId);
     }
 }

--- a/common/src/main/java/me/shedaniel/architectury/registry/Registry.java
+++ b/common/src/main/java/me/shedaniel/architectury/registry/Registry.java
@@ -49,10 +49,15 @@ public interface Registry<T> extends Iterable<T> {
     @Nullable
     ResourceLocation getId(T obj);
     
+    int getRawId(T obj);
+    
     Optional<ResourceKey<T>> getKey(T obj);
     
     @Nullable
     T get(ResourceLocation id);
+    
+    @Nullable
+    T byRawId(int rawId);
     
     boolean contains(ResourceLocation id);
     

--- a/common/src/main/java/me/shedaniel/architectury/registry/registries/RegistryBuilder.java
+++ b/common/src/main/java/me/shedaniel/architectury/registry/registries/RegistryBuilder.java
@@ -17,13 +17,26 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package me.shedaniel.architectury.core;
+package me.shedaniel.architectury.registry.registries;
 
-import net.minecraft.world.item.crafting.Recipe;
-import net.minecraft.world.item.crafting.RecipeSerializer;
+import me.shedaniel.architectury.core.RegistryEntry;
+import me.shedaniel.architectury.registry.Registry;
+import org.jetbrains.annotations.NotNull;
 
-/**
- * The equivalent of {@link RecipeSerializer} to use in common that has forge registry entries extended.
- */
-public abstract class AbstractRecipeSerializer<T extends Recipe<?>> extends RegistryEntry<T> implements RecipeSerializer<T> {
+public interface RegistryBuilder<T extends RegistryEntry<T>> {
+    @NotNull
+    Registry<T> build();
+    
+    @NotNull
+    RegistryBuilder<T> option(@NotNull RegistryOption option);
+    
+    @NotNull
+    default RegistryBuilder<T> saveToDisc() {
+        return option(StandardRegistryOption.SAVE_TO_DISC);
+    }
+    
+    @NotNull
+    default RegistryBuilder<T> syncToClients() {
+        return option(StandardRegistryOption.SYNC_TO_CLIENTS);
+    }
 }

--- a/common/src/main/java/me/shedaniel/architectury/registry/registries/RegistryOption.java
+++ b/common/src/main/java/me/shedaniel/architectury/registry/registries/RegistryOption.java
@@ -17,13 +17,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package me.shedaniel.architectury.core;
+package me.shedaniel.architectury.registry.registries;
 
-import net.minecraft.world.item.crafting.Recipe;
-import net.minecraft.world.item.crafting.RecipeSerializer;
-
-/**
- * The equivalent of {@link RecipeSerializer} to use in common that has forge registry entries extended.
- */
-public abstract class AbstractRecipeSerializer<T extends Recipe<?>> extends RegistryEntry<T> implements RecipeSerializer<T> {
+public interface RegistryOption {
 }

--- a/common/src/main/java/me/shedaniel/architectury/registry/registries/StandardRegistryOption.java
+++ b/common/src/main/java/me/shedaniel/architectury/registry/registries/StandardRegistryOption.java
@@ -17,11 +17,15 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package me.shedaniel.architectury.mixin.forge;
+package me.shedaniel.architectury.registry.registries;
 
-import me.shedaniel.architectury.core.AbstractRecipeSerializer;
-import org.spongepowered.asm.mixin.Mixin;
-
-@Mixin(AbstractRecipeSerializer.class)
-public class MixinAbstractRecipeSerializer {
+public enum StandardRegistryOption implements RegistryOption {
+    /**
+     * Denote that the registry should save to disc and persist. Defaulted false.
+     */
+    SAVE_TO_DISC,
+    /**
+     * Denote that the registry should sync its contents to clients. Defaulted false.
+     */
+    SYNC_TO_CLIENTS,
 }

--- a/fabric/src/main/java/me/shedaniel/architectury/registry/fabric/RegistriesImpl.java
+++ b/fabric/src/main/java/me/shedaniel/architectury/registry/fabric/RegistriesImpl.java
@@ -166,6 +166,11 @@ public class RegistriesImpl {
         }
         
         @Override
+        public int getRawId(T obj) {
+            return delegate.getId(obj);
+        }
+        
+        @Override
         public Optional<ResourceKey<T>> getKey(T obj) {
             return delegate.getResourceKey(obj);
         }
@@ -173,6 +178,11 @@ public class RegistriesImpl {
         @Override
         public @Nullable T get(ResourceLocation id) {
             return delegate.get(id);
+        }
+        
+        @Override
+        public T byRawId(int rawId) {
+            return delegate.byId(rawId);
         }
         
         @Override

--- a/fabric/src/main/java/me/shedaniel/architectury/registry/fabric/RegistriesImpl.java
+++ b/fabric/src/main/java/me/shedaniel/architectury/registry/fabric/RegistriesImpl.java
@@ -20,9 +20,16 @@
 package me.shedaniel.architectury.registry.fabric;
 
 import com.google.common.base.Objects;
+import me.shedaniel.architectury.core.RegistryEntry;
 import me.shedaniel.architectury.registry.Registries;
 import me.shedaniel.architectury.registry.Registry;
 import me.shedaniel.architectury.registry.RegistrySupplier;
+import me.shedaniel.architectury.registry.registries.RegistryBuilder;
+import me.shedaniel.architectury.registry.registries.RegistryOption;
+import me.shedaniel.architectury.registry.registries.StandardRegistryOption;
+import net.fabricmc.fabric.api.event.registry.FabricRegistryBuilder;
+import net.fabricmc.fabric.api.event.registry.RegistryAttribute;
+import net.minecraft.core.MappedRegistry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.LazyLoadedValue;
@@ -63,6 +70,36 @@ public class RegistriesImpl {
         @Override
         public <T> Registry<T> get(net.minecraft.core.Registry<T> registry) {
             return new RegistryImpl<>(registry);
+        }
+        
+        @Override
+        @NotNull
+        public <T extends RegistryEntry<T>> RegistryBuilder<T> builder(Class<T> type, ResourceLocation registryId) {
+            return new RegistryBuilderWrapper<>(FabricRegistryBuilder.createSimple(type, registryId));
+        }
+    }
+    
+    public static class RegistryBuilderWrapper<T extends RegistryEntry<T>> implements RegistryBuilder<T> {
+        @NotNull
+        private FabricRegistryBuilder<T, MappedRegistry<T>> builder;
+        
+        public RegistryBuilderWrapper(@NotNull FabricRegistryBuilder<T, MappedRegistry<T>> builder) {
+            this.builder = builder;
+        }
+        
+        @Override
+        public @NotNull Registry<T> build() {
+            return RegistryProviderImpl.INSTANCE.get(builder.buildAndRegister());
+        }
+        
+        @Override
+        public @NotNull RegistryBuilder<T> option(@NotNull RegistryOption option) {
+            if (option == StandardRegistryOption.SAVE_TO_DISC) {
+                this.builder.attribute(RegistryAttribute.PERSISTED);
+            } else if (option == StandardRegistryOption.SYNC_TO_CLIENTS) {
+                this.builder.attribute(RegistryAttribute.SYNCED);
+            }
+            return this;
         }
     }
     

--- a/fabric/src/main/java/me/shedaniel/architectury/registry/fabric/ReloadListenersImpl.java
+++ b/fabric/src/main/java/me/shedaniel/architectury/registry/fabric/ReloadListenersImpl.java
@@ -39,7 +39,7 @@ public class ReloadListenersImpl {
     public static void registerReloadListener(PackType type, PreparableReloadListener listener) {
         byte[] bytes = new byte[8];
         RANDOM.nextBytes(bytes);
-        ResourceLocation id = new ResourceLocation("architectury:reload_" + StringUtils.leftPad(Math.abs(Longs.fromByteArray(bytes)) + "", 19));
+        ResourceLocation id = new ResourceLocation("architectury:reload_" + StringUtils.leftPad(Math.abs(Longs.fromByteArray(bytes)) + "", 19, '0'));
         ResourceManagerHelper.get(type).registerReloadListener(new IdentifiableResourceReloadListener() {
             @Override
             public ResourceLocation getFabricId() {

--- a/forge/src/main/java/me/shedaniel/architectury/mixin/forge/MixinRegistryEntry.java
+++ b/forge/src/main/java/me/shedaniel/architectury/mixin/forge/MixinRegistryEntry.java
@@ -17,13 +17,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package me.shedaniel.architectury.core;
+package me.shedaniel.architectury.mixin.forge;
 
-import net.minecraft.world.item.crafting.Recipe;
-import net.minecraft.world.item.crafting.RecipeSerializer;
+import me.shedaniel.architectury.core.RegistryEntry;
+import org.spongepowered.asm.mixin.Mixin;
 
-/**
- * The equivalent of {@link RecipeSerializer} to use in common that has forge registry entries extended.
- */
-public abstract class AbstractRecipeSerializer<T extends Recipe<?>> extends RegistryEntry<T> implements RecipeSerializer<T> {
+@Mixin(RegistryEntry.class)
+public class MixinRegistryEntry<T> {
 }

--- a/forge/src/main/java/me/shedaniel/architectury/plugin/forge/ArchitecturyMixinPlugin.java
+++ b/forge/src/main/java/me/shedaniel/architectury/plugin/forge/ArchitecturyMixinPlugin.java
@@ -61,7 +61,7 @@ public class ArchitecturyMixinPlugin implements IMixinConfigPlugin {
     public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
         // Inject our own sugar
         switch (mixinClassName) {
-            case "me.shedaniel.architectury.mixin.forge.MixinAbstractRecipeSerializer":
+            case "me.shedaniel.architectury.mixin.forge.MixinRegistryEntry":
                 targetClass.superName = "net/minecraftforge/registries/ForgeRegistryEntry";
                 for (MethodNode method : targetClass.methods) {
                     if (Objects.equals(method.name, "<init>")) {
@@ -77,9 +77,7 @@ public class ArchitecturyMixinPlugin implements IMixinConfigPlugin {
                     }
                 }
                 String recipeSerializer = targetClass.interfaces.get(0);
-                if (targetClass.signature != null) {
-                    targetClass.signature = targetClass.signature.replace("Ljava/lang/Object;", "Lnet/minecraftforge/registries/ForgeRegistryEntry<L" + recipeSerializer + "<*>;>");
-                }
+                targetClass.signature = "<T::Lnet/minecraftforge/registries/IForgeRegistryEntry<TT;>;>Lnet/minecraftforge/registries/ForgeRegistryEntry<TT;>;";
                 break;
         }
     }

--- a/forge/src/main/java/me/shedaniel/architectury/registry/forge/RegistriesImpl.java
+++ b/forge/src/main/java/me/shedaniel/architectury/registry/forge/RegistriesImpl.java
@@ -37,6 +37,7 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.ForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryManager;
@@ -82,7 +83,7 @@ public class RegistriesImpl {
         public <T> Registry<T> get(ResourceKey<net.minecraft.core.Registry<T>> registryKey) {
             return get(RegistryManager.ACTIVE.getRegistry(registryKey.location()));
         }
-    
+        
         public <T> Registry<T> get(IForgeRegistry registry) {
             return new ForgeBackedRegistryImpl<>(this.registry, registry);
         }
@@ -162,7 +163,7 @@ public class RegistriesImpl {
                 public @NotNull ResourceLocation getRegistryId() {
                     return delegate.key().location();
                 }
-    
+                
                 @Override
                 public @NotNull ResourceLocation getId() {
                     return id;
@@ -211,6 +212,11 @@ public class RegistriesImpl {
         }
         
         @Override
+        public int getRawId(T obj) {
+            return delegate.getId(obj);
+        }
+        
+        @Override
         public Optional<ResourceKey<T>> getKey(T t) {
             return delegate.getResourceKey(t);
         }
@@ -219,6 +225,11 @@ public class RegistriesImpl {
         @Nullable
         public T get(ResourceLocation id) {
             return delegate.get(id);
+        }
+        
+        @Override
+        public T byRawId(int rawId) {
+            return delegate.byId(rawId);
         }
         
         @Override
@@ -357,6 +368,11 @@ public class RegistriesImpl {
         }
         
         @Override
+        public int getRawId(T obj) {
+            return ((ForgeRegistry<T>) delegate).getID(obj);
+        }
+        
+        @Override
         public Optional<ResourceKey<T>> getKey(T t) {
             return Optional.ofNullable(getId(t)).map(id -> ResourceKey.create(key(), id));
         }
@@ -365,6 +381,11 @@ public class RegistriesImpl {
         @Nullable
         public T get(ResourceLocation id) {
             return delegate.getValue(id);
+        }
+        
+        @Override
+        public T byRawId(int rawId) {
+            return ((ForgeRegistry<T>) delegate).getValue(rawId);
         }
         
         @Override

--- a/forge/src/main/resources/architectury.mixins.json
+++ b/forge/src/main/resources/architectury.mixins.json
@@ -7,7 +7,7 @@
   "client": [
   ],
   "mixins": [
-    "BiomeGenerationSettingsBuilderAccessor", "MixinAbstractRecipeSerializer", "MixinBlockEntity", "MixinBlockEntityExtension",
+    "BiomeGenerationSettingsBuilderAccessor", "MixinRegistryEntry", "MixinBlockEntity", "MixinBlockEntityExtension",
     "MobSpawnSettingsBuilderAccessor"
   ],
   "injectors": {


### PR DESCRIPTION
Close #21.

Adds `RegistryEntry<T>`, a class that will extend `ForgeRegistryEntry<T>` on Forge, we don't quite need classes like `AbstractRecipeSerializer` anymore in the future.

Allows creation of modded registries via Fabric API's `FabricRegistryBuilder` and Forge API's `RegistryBuilder`, with options to sync to clients and save to disk.

This needs testing in both production and development environments.