### PR TITLE
Implement phases for BiomeModifications on Forge

### DIFF
--- a/common/src/main/java/me/shedaniel/architectury/hooks/biome/BiomeHooks.java
+++ b/common/src/main/java/me/shedaniel/architectury/hooks/biome/BiomeHooks.java
@@ -391,6 +391,11 @@ public final class BiomeHooks {
         }
         
         @Override
+        public List<Supplier<ConfiguredFeature<?, ?>>> getFeatures(GenerationStep.Decoration decoration) {
+            return settings.features().get(decoration.ordinal());
+        }
+        
+        @Override
         public List<List<Supplier<ConfiguredFeature<?, ?>>>> getFeatures() {
             return settings.features();
         }

--- a/common/src/main/java/me/shedaniel/architectury/hooks/biome/GenerationProperties.java
+++ b/common/src/main/java/me/shedaniel/architectury/hooks/biome/GenerationProperties.java
@@ -19,6 +19,7 @@
 
 package me.shedaniel.architectury.hooks.biome;
 
+import net.minecraft.world.entity.animal.Panda;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
@@ -33,6 +34,8 @@ public interface GenerationProperties {
     Optional<Supplier<ConfiguredSurfaceBuilder<?>>> getSurfaceBuilder();
     
     List<Supplier<ConfiguredWorldCarver<?>>> getCarvers(GenerationStep.Carving carving);
+    
+    List<Supplier<ConfiguredFeature<?, ?>>> getFeatures(GenerationStep.Decoration decoration);
     
     List<List<Supplier<ConfiguredFeature<?, ?>>>> getFeatures();
     

--- a/common/src/main/java/me/shedaniel/architectury/registry/BiomeModifications.java
+++ b/common/src/main/java/me/shedaniel/architectury/registry/BiomeModifications.java
@@ -37,16 +37,17 @@ import java.util.function.Predicate;
  * with the corresponding Forge EventPriority shown in brackets:
  *
  * <ol>
- *     <li>{@link #addProperties(Predicate, BiConsumer) Adding} new features to biomes. [HIGH]</li>
- *     <li>{@link #removeProperties(Predicate, BiConsumer)  Removing} existing features from biomes. [NORMAL]</li>
- *     <li>{@link #replaceProperties(Predicate, BiConsumer) Replacing} existing features with new ones. [LOW]</li>
- *     <li>Generic {@link #postProcessProperties(Predicate, BiConsumer) Post-Processing} of already modified biome features. [LOWEST]</li>
+ *     <li>{@linkplain #addProperties(Predicate, BiConsumer) Adding} new features to biomes. [HIGH]</li>
+ *     <li>{@linkplain #removeProperties(Predicate, BiConsumer)  Removing} existing features from biomes. [NORMAL]</li>
+ *     <li>{@linkplain #replaceProperties(Predicate, BiConsumer) Replacing} existing features with new ones. [LOW]</li>
+ *     <li>Generic {@linkplain #postProcessProperties(Predicate, BiConsumer) Post-Processing} of already modified biome features. [LOWEST]</li>
  * </ol>
  *
  * Keep in mind that it isn't strictly <b>required</b> that you use these phases accordingly
  * (i.e., you may also add features during Post-Processing, for example); they mostly serve to
  * add a predictable order to biome modifications.
  */
+@SuppressWarnings("JavadocReference")
 public final class BiomeModifications {
     public static void addProperties(BiConsumer<BiomeContext, BiomeProperties.Mutable> modifier) {
         BiomeModifications.addProperties(Predicates.alwaysTrue(), modifier);

--- a/common/src/main/java/me/shedaniel/architectury/registry/BiomeModifications.java
+++ b/common/src/main/java/me/shedaniel/architectury/registry/BiomeModifications.java
@@ -27,6 +27,26 @@ import net.minecraft.resources.ResourceLocation;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
+/**
+ * This class provides a cross-platform API to modify Biome features and properties.
+ *
+ * <p> Changes to the biomes are hereby done in four distinct "phases", akin to Fabric API's
+ * {@link net.fabricmc.fabric.api.biome.v1.ModificationPhase} enum.
+ *
+ * <p> The order in which these phases get processed is as follows,
+ * with the corresponding Forge EventPriority shown in brackets:
+ *
+ * <ol>
+ *     <li>{@link #addProperties(Predicate, BiConsumer) Adding} new features to biomes. [HIGH]</li>
+ *     <li>{@link #removeProperties(Predicate, BiConsumer)  Removing} existing features from biomes. [NORMAL]</li>
+ *     <li>{@link #replaceProperties(Predicate, BiConsumer) Replacing} existing features with new ones. [LOW]</li>
+ *     <li>Generic {@link #postProcessProperties(Predicate, BiConsumer) Post-Processing} of already modified biome features. [LOWEST]</li>
+ * </ol>
+ *
+ * Keep in mind that it isn't strictly <b>required</b> that you use these phases accordingly
+ * (i.e., you may also add features during Post-Processing, for example); they mostly serve to
+ * add a predictable order to biome modifications.
+ */
 public final class BiomeModifications {
     public static void addProperties(BiConsumer<BiomeContext, BiomeProperties.Mutable> modifier) {
         BiomeModifications.addProperties(Predicates.alwaysTrue(), modifier);

--- a/forge/src/main/java/me/shedaniel/architectury/registry/forge/BiomeModificationsImpl.java
+++ b/forge/src/main/java/me/shedaniel/architectury/registry/forge/BiomeModificationsImpl.java
@@ -174,7 +174,12 @@ public class BiomeModificationsImpl {
         public @NotNull List<Supplier<ConfiguredWorldCarver<?>>> getCarvers(GenerationStep.Carving carving) {
             return generation.getCarvers(carving);
         }
-        
+    
+        @Override
+        public List<Supplier<ConfiguredFeature<?, ?>>> getFeatures(GenerationStep.Decoration decoration) {
+            return generation.getFeatures(decoration);
+        }
+    
         @Override
         public @NotNull List<List<Supplier<ConfiguredFeature<?, ?>>>> getFeatures() {
             return ((BiomeGenerationSettingsBuilderAccessor) generation).getFeatures();


### PR DESCRIPTION
I also added some basic Javadoc to explain the purpose of the four "phases".

Currently, the following priority holds:
1. Additions (HIGH)
2. Removals (NORMAL)
3. Replacements (LOW)
4. Post-Processing (LOWEST)

Feel free to give additional opinions on the matter before merging, as this is "only" medium-priority.

This feature, if applicable, will also be ported to 1.17 (we can just cherry pick the commits or merge later), however I think Forge *may* be getting an overhaul to their Biome system anyways so we may not need it like this in future versions