### PR TITLE
Wrapper for BlockEntityType.Builder

### DIFF
--- a/common/src/main/java/dev/architectury/hooks/block/BlockEntityHooks.java
+++ b/common/src/main/java/dev/architectury/hooks/block/BlockEntityHooks.java
@@ -27,6 +27,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
 
@@ -47,7 +48,7 @@ public class BlockEntityHooks {
             this.validBlocks = validBlocks;
         }
         
-        public BlockEntityType<T> build(Type<?> type) {
+        public BlockEntityType<T> build(@Nullable Type<?> type) {
             return new BlockEntityType<>(this.constructor::create, this.validBlocks, type);
         }
     }

--- a/common/src/main/java/dev/architectury/hooks/block/BlockEntityHooks.java
+++ b/common/src/main/java/dev/architectury/hooks/block/BlockEntityHooks.java
@@ -19,11 +19,37 @@
 
 package dev.architectury.hooks.block;
 
+import com.google.common.collect.ImmutableSet;
+import com.mojang.datafixers.types.Type;
 import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.Set;
 
 public class BlockEntityHooks {
     private BlockEntityHooks() {
+    }
+    
+    public static <T extends BlockEntity> TypeBuilder<T> builder(Constructor<? extends T> constructor, Block... blocks) {
+        return new TypeBuilder<>(constructor, ImmutableSet.copyOf(blocks));
+    }
+    
+    public static class TypeBuilder<T extends BlockEntity> {
+        private final Constructor<? extends T> constructor;
+        private final Set<Block> validBlocks;
+        
+        private TypeBuilder(Constructor<? extends T> constructor, Set<Block> validBlocks) {
+            this.constructor = constructor;
+            this.validBlocks = validBlocks;
+        }
+        
+        public BlockEntityType<T> build(Type<?> type) {
+            return new BlockEntityType<>(this.constructor::create, this.validBlocks, type);
+        }
     }
     
     /**
@@ -32,5 +58,10 @@ public class BlockEntityHooks {
     @ExpectPlatform
     public static void syncData(BlockEntity entity) {
         throw new AssertionError();
+    }
+    
+    @FunctionalInterface
+    public interface Constructor<T extends BlockEntity> {
+        T create(BlockPos pos, BlockState state);
     }
 }

--- a/common/src/main/resources/architectury.accessWidener
+++ b/common/src/main/resources/architectury.accessWidener
@@ -40,3 +40,4 @@ mutable field net/minecraft/world/level/biome/BiomeSpecialEffects ambientAdditio
 accessible field net/minecraft/world/level/biome/BiomeSpecialEffects backgroundMusic Ljava/util/Optional;
 mutable field net/minecraft/world/level/biome/BiomeSpecialEffects backgroundMusic Ljava/util/Optional;
 accessible method net/minecraft/world/level/storage/LevelResource <init> (Ljava/lang/String;)V
+accessible class net/minecraft/world/level/block/entity/BlockEntityType$BlockEntitySupplier

--- a/fabric/src/main/resources/architectury.accessWidener
+++ b/fabric/src/main/resources/architectury.accessWidener
@@ -98,3 +98,4 @@ mutable field net/minecraft/world/level/biome/BiomeSpecialEffects ambientAdditio
 accessible field net/minecraft/world/level/biome/BiomeSpecialEffects backgroundMusic Ljava/util/Optional;
 mutable field net/minecraft/world/level/biome/BiomeSpecialEffects backgroundMusic Ljava/util/Optional;
 accessible method net/minecraft/world/level/storage/LevelResource <init> (Ljava/lang/String;)V
+accessible class net/minecraft/world/level/block/entity/BlockEntityType$BlockEntitySupplier

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cf_type=release
 
 archives_base_name=architectury
 archives_base_name_snapshot=architectury-snapshot
-base_version=2.0
+base_version=2.1
 maven_group=dev.architectury
 
 fabric_loader_version=0.11.6


### PR DESCRIPTION
Since 1.17, `BlockEntityType$BlockEntitySupplier ` is now package-private, this adds a hook to allow constructing the block entity type without AW / Mixin.

Signed-off-by: shedaniel <daniel@shedaniel.me>