### PR TITLE
[Now GPG key signed] Fixed PlayerAttackInvoker mixing loading crash on server side

### DIFF
--- a/fabric/src/main/java/dev/architectury/mixin/fabric/client/ClientPlayerAttackInvoker.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/client/ClientPlayerAttackInvoker.java
@@ -17,9 +17,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package dev.architectury.mixin.fabric;
+package dev.architectury.mixin.fabric.client;
 
 import dev.architectury.event.events.common.EntityEvent;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.player.RemotePlayer;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
@@ -28,8 +30,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = {Player.class})
-public class PlayerAttackInvoker {
+@Mixin(value = {LocalPlayer.class, RemotePlayer.class})
+public class ClientPlayerAttackInvoker {
     @Inject(method = "hurt", at = @At("HEAD"), cancellable = true)
     private void hurt(DamageSource damageSource, float f, CallbackInfoReturnable<Boolean> cir) {
         if (EntityEvent.LIVING_HURT.invoker().hurt((LivingEntity) (Object) this, damageSource, f).isFalse() && (Object) this instanceof Player) {

--- a/fabric/src/main/resources/architectury.mixins.json
+++ b/fabric/src/main/resources/architectury.mixins.json
@@ -16,7 +16,8 @@
     "client.MixinMouseHandler",
     "client.MixinMultiPlayerGameMode",
     "client.MixinScreen",
-    "client.MixinTextureAtlas"
+    "client.MixinTextureAtlas",
+    "client.ClientPlayerAttackInvoker"
   ],
   "mixins": [
     "ExplosionPreInvoker",


### PR DESCRIPTION
Closed #136 so that I could create a new PR with a commit that was GPG signed, allowing CLAassistant to confirm my email.

Split PlayerAttackInvoker into seperate client and server side mixins to avoid the following error on server side:

```
[main/WARN]: Error loading class: net/minecraft/class_746 (java.lang.ClassNotFoundException: net/minecraft/class_746)
[main/WARN]: @Mixin target net.minecraft.class_746 was not found architectury.mixins.json:PlayerAttackInvoker
[main/WARN]: Error loading class: net/minecraft/class_745 (java.lang.ClassNotFoundException: net/minecraft/class_745)
[main/WARN]: @Mixin target net.minecraft.class_745 was not found architectury.mixins.json:PlayerAttackInvoker
```

Signed-off-by: apple <davidalb97@hotmail.com>