### PR TITLE
Add LifecycleEvent.SETUP for manipulating things after normal initial…

### DIFF
--- a/common/src/main/java/dev/architectury/event/events/client/ClientLifecycleEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/client/ClientLifecycleEvent.java
@@ -49,7 +49,9 @@ public interface ClientLifecycleEvent {
      * <p> This happens during {@code FMLClientSetupEvent} on Forge,
      * or when Architectury API's client entrypoint initialises on Fabric.
      * <p>
-     * Registries should be initialised here.
+     * Registries should have been initialised by this point, but there
+     * are no such limits in place, as you modify the registry beyond this point
+     * on non-Forge environments.
      */
     Event<ClientState> CLIENT_SETUP = EventFactory.createLoop();
     

--- a/common/src/main/java/dev/architectury/event/events/client/ClientLifecycleEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/client/ClientLifecycleEvent.java
@@ -50,7 +50,7 @@ public interface ClientLifecycleEvent {
      * or when Architectury API's client entrypoint initialises on Fabric.
      * <p>
      * Registries should have been initialised by this point, but there
-     * are no such limits in place, as you modify the registry beyond this point
+     * are no such guarantees, as you can modify the registry beyond this point
      * on non-Forge environments.
      */
     Event<ClientState> CLIENT_SETUP = EventFactory.createLoop();

--- a/common/src/main/java/dev/architectury/event/events/client/ClientLifecycleEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/client/ClientLifecycleEvent.java
@@ -48,6 +48,8 @@ public interface ClientLifecycleEvent {
      * Invoked once client setup has begun.
      * <p> This happens during {@code FMLClientSetupEvent} on Forge,
      * or when Architectury API's client entrypoint initialises on Fabric.
+     * <p>
+     * Registries should be initialised here.
      */
     Event<ClientState> CLIENT_SETUP = EventFactory.createLoop();
     

--- a/common/src/main/java/dev/architectury/event/events/common/LifecycleEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/common/LifecycleEvent.java
@@ -21,6 +21,7 @@ package dev.architectury.event.events.common;
 
 import dev.architectury.event.Event;
 import dev.architectury.event.EventFactory;
+import dev.architectury.event.events.client.ClientLifecycleEvent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
@@ -88,6 +89,14 @@ public interface LifecycleEvent {
      * @see ServerLevelState#act(Level)
      */
     Event<ServerLevelState> SERVER_LEVEL_SAVE = EventFactory.createLoop();
+    /**
+     * Invoked once common setup has begun.
+     * <p> This happens during {@code FMLCommonSetupEvent} on Forge,
+     * or when Architectury API's entrypoint initialises on Fabric.
+     * <p>
+     * Registries should be initialised here.
+     */
+    Event<Runnable> SETUP = EventFactory.createLoop();
     
     interface InstanceState<T> {
         /**

--- a/common/src/main/java/dev/architectury/event/events/common/LifecycleEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/common/LifecycleEvent.java
@@ -94,7 +94,7 @@ public interface LifecycleEvent {
      * or when Architectury API's entrypoint initialises on Fabric.
      * <p>
      * Registries should have been initialised by this point, but there
-     * are no such limits in place, as you modify the registry beyond this point
+     * are no such guarantees, as you can modify the registry beyond this point
      * on non-Forge environments.
      */
     Event<Runnable> SETUP = EventFactory.createLoop();

--- a/common/src/main/java/dev/architectury/event/events/common/LifecycleEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/common/LifecycleEvent.java
@@ -91,7 +91,7 @@ public interface LifecycleEvent {
     /**
      * Invoked once common setup has begun.
      * <p> This happens during {@code FMLCommonSetupEvent} on Forge,
-     * or when Architectury API's entrypoint initialises on Fabric.
+     * or when Architectury API's client/server entrypoint initialises on Fabric.
      * <p>
      * Registries should have been initialised by this point, but there
      * are no such guarantees, as you can modify the registry beyond this point

--- a/common/src/main/java/dev/architectury/event/events/common/LifecycleEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/common/LifecycleEvent.java
@@ -21,7 +21,6 @@ package dev.architectury.event.events.common;
 
 import dev.architectury.event.Event;
 import dev.architectury.event.EventFactory;
-import dev.architectury.event.events.client.ClientLifecycleEvent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
@@ -94,7 +93,9 @@ public interface LifecycleEvent {
      * <p> This happens during {@code FMLCommonSetupEvent} on Forge,
      * or when Architectury API's entrypoint initialises on Fabric.
      * <p>
-     * Registries should be initialised here.
+     * Registries should have been initialised by this point, but there
+     * are no such limits in place, as you modify the registry beyond this point
+     * on non-Forge environments.
      */
     Event<Runnable> SETUP = EventFactory.createLoop();
     

--- a/fabric/src/main/java/dev/architectury/init/fabric/ArchitecturyServer.java
+++ b/fabric/src/main/java/dev/architectury/init/fabric/ArchitecturyServer.java
@@ -19,16 +19,10 @@
 
 package dev.architectury.init.fabric;
 
-import dev.architectury.event.events.client.ClientLifecycleEvent;
 import dev.architectury.event.events.common.LifecycleEvent;
-import dev.architectury.networking.fabric.SpawnEntityPacket;
-import net.minecraft.client.Minecraft;
 
-public class ArchitecturyClient {
+public class ArchitecturyServer {
     public static void init() {
         LifecycleEvent.SETUP.invoker().run();
-        ClientLifecycleEvent.CLIENT_SETUP.invoker().stateChanged(Minecraft.getInstance());
-        
-        SpawnEntityPacket.register();
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -22,6 +22,9 @@
     "main": [
       "dev.architectury.utils.fabric.GameInstanceImpl::init"
     ],
+    "server": [
+      "dev.architectury.init.fabric.ArchitecturyServer::init"
+    ],
     "client": [
       "dev.architectury.init.fabric.ArchitecturyClient::init"
     ],

--- a/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
+++ b/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
@@ -58,6 +58,7 @@ import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fmllegacy.server.ServerLifecycleHooks;
 import net.minecraftforge.fmlserverevents.*;
 
@@ -423,6 +424,9 @@ public class EventHandlerImplCommon {
     }
     
     public static class ModBasedEventHandler {
-        
+        @SubscribeEvent(priority = EventPriority.HIGH)
+        public static void event(FMLCommonSetupEvent event) {
+            LifecycleEvent.SETUP.invoker().run();
+        }
     }
 }


### PR DESCRIPTION
…ization

Should be useful for setting up (properties?) for when registries _should_ be done.
I know fabric doesn't have a hard limit on where you can register things, but this should be useful enough for most cases.