### PR TITLE
ScreenInputDelegate: Call MOUSE_DRAGGED_POST correctly

### DIFF
--- a/fabric/src/main/java/dev/architectury/impl/fabric/ScreenInputDelegate.java
+++ b/fabric/src/main/java/dev/architectury/impl/fabric/ScreenInputDelegate.java
@@ -41,7 +41,7 @@ public interface ScreenInputDelegate {
                 return true;
             if (parent.mouseDragged(d, e, i, f, g))
                 return true;
-            return ClientScreenInputEvent.MOUSE_DRAGGED_PRE.invoker().mouseDragged(Minecraft.getInstance(), parent, d, e, i, f, g).isPresent();
+            return ClientScreenInputEvent.MOUSE_DRAGGED_POST.invoker().mouseDragged(Minecraft.getInstance(), parent, d, e, i, f, g).isPresent();
         }
         
         @Override


### PR DESCRIPTION
It was erroneously calling the PRE event twice.

I didn't test this.