### PR TITLE
@Redirect workaround for closing #152

### DIFF
--- a/fabric/src/main/java/dev/architectury/impl/fabric/ScreenInputDelegate.java
+++ b/fabric/src/main/java/dev/architectury/impl/fabric/ScreenInputDelegate.java
@@ -36,15 +36,6 @@ public interface ScreenInputDelegate {
         }
         
         @Override
-        public boolean mouseDragged(double d, double e, int i, double f, double g) {
-            if (ClientScreenInputEvent.MOUSE_DRAGGED_PRE.invoker().mouseDragged(Minecraft.getInstance(), parent, d, e, i, f, g).isPresent())
-                return true;
-            if (parent.mouseDragged(d, e, i, f, g))
-                return true;
-            return ClientScreenInputEvent.MOUSE_DRAGGED_POST.invoker().mouseDragged(Minecraft.getInstance(), parent, d, e, i, f, g).isPresent();
-        }
-        
-        @Override
         public boolean charTyped(char c, int i) {
             if (ClientScreenInputEvent.CHAR_TYPED_PRE.invoker().charTyped(Minecraft.getInstance(), parent, c, i).isPresent())
                 return true;

--- a/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinMouseHandler.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinMouseHandler.java
@@ -165,6 +165,6 @@ public class MixinMouseHandler {
         if (screen.mouseDragged(mouseX, mouseY, button, deltaX, deltaY)) {
             return true;
         }
-        return ClientScreenInputEvent.MOUSE_DRAGGED_PRE.invoker().mouseDragged(Minecraft.getInstance(), screen, mouseX, mouseY, button, deltaX, deltaY).isPresent();
+        return ClientScreenInputEvent.MOUSE_DRAGGED_POST.invoker().mouseDragged(Minecraft.getInstance(), screen, mouseX, mouseY, button, deltaX, deltaY).isPresent();
     }
 }


### PR DESCRIPTION
This reworks the mixin for implementing mouse drag events, this is more dangerous and incompatible compared to just wrapping the screen.

Whether there are other mods redirecting the same method should be looked into for this issue, the reason why I originally implemented this mixin with the `@ModifyVariable` is that I needed to get the return value of the vanilla `mouseDragged` method, we could potentially do raw asm here and add our transformation before the `pop`, but that would be way overkill.

```asm
 0 aload_1
 1 dload_2
 2 dload 4
 4 aload_0
 5 getfield #52 <net/minecraft/client/MouseHandler.activeButton : I>
 8 dload 6
10 dload 8
12 invokevirtual #482 <net/minecraft/client/gui/screens/Screen.mouseDragged : (DDIDD)Z>
15 pop <-- we need to inject before this
16 return
```

If I am missing some mixin magic features that could solve this issue without `@Redirect`, please do let me know.