### PR TITLE
Add AWs for RenderType

### DIFF
--- a/common/src/main/resources/architectury-common.accessWidener
+++ b/common/src/main/resources/architectury-common.accessWidener
@@ -49,3 +49,5 @@ transitive-mutable field net/minecraft/world/level/Explosion source Lnet/minecra
 transitive-accessible field net/minecraft/world/level/Explosion radius F
 transitive-mutable field net/minecraft/world/level/Explosion radius F
 transitive-accessible method net/minecraft/world/entity/player/Player closeContainer ()V
+transitive-accessible method net/minecraft/client/renderer/RenderType create (Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;IZZLnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType;
+transitive-accessible class net/minecraft/client/renderer/RenderType$CompositeState

--- a/fabric/src/main/resources/architectury.accessWidener
+++ b/fabric/src/main/resources/architectury.accessWidener
@@ -106,3 +106,5 @@ accessible field net/minecraft/world/level/Explosion source Lnet/minecraft/world
 mutable field net/minecraft/world/level/Explosion source Lnet/minecraft/world/entity/Entity;
 accessible field net/minecraft/world/level/Explosion radius F
 mutable field net/minecraft/world/level/Explosion radius F
+accessible method net/minecraft/client/renderer/RenderType create (Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;IZZLnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType;
+accessible class net/minecraft/client/renderer/RenderType$CompositeState


### PR DESCRIPTION
1.18 made RenderType.create as well as the entire inner CompositeState class private / protected respectively, so I've added some access wideners to arch that solve the issue for downstream mods. The reason I've decided to add this to arch itself is that:

1) We can reasonably expect a large number of mods using arch to want to rely on RenderTypes and
2) Forge implements these by default in their Forge "mod" AT

Also putting this on prio high and immediate last call since the changes are *very minor* and **very unlikely to cause any issues**