### PR TITLE
Introduce EntitySpawnExtension

### DIFF
--- a/common/src/main/java/dev/architectury/extensions/network/EntitySpawnExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/network/EntitySpawnExtension.java
@@ -23,7 +23,7 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.Entity;
 
 /**
- * Extension to attach additional spawn data to packets sent to client.
+ * This interface can be implemented on {@linkplain Entity entities} to attach additional spawn data to packets sent to client.
  * This is used in conjunction with {@link dev.architectury.networking.NetworkManager#createAddEntityPacket(Entity)}
  */
 public interface EntitySpawnExtension {

--- a/common/src/main/java/dev/architectury/extensions/network/EntitySpawnExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/network/EntitySpawnExtension.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.extensions.network;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.Entity;
+
+/**
+ * Extension to attach additional spawn data to packets sent to client.
+ * This is used in conjunction with {@link dev.architectury.networking.NetworkManager#createAddEntityPacket(Entity)}
+ */
+public interface EntitySpawnExtension {
+    void saveAdditionalSpawnData(FriendlyByteBuf buf);
+    
+    void loadAdditionalSpawnData(FriendlyByteBuf buf);
+}

--- a/common/src/main/java/dev/architectury/networking/NetworkManager.java
+++ b/common/src/main/java/dev/architectury/networking/NetworkManager.java
@@ -99,7 +99,7 @@ public final class NetworkManager {
      * This packet is needed everytime any mod adds a non-living entity.
      * The entity should override {@link Entity#getAddEntityPacket()} to point to this method!
      * <p>
-     * Additionally, entities may extend {@link dev.architectury.extensions.network.EntitySpawnExtension}
+     * Additionally, entities may implement {@link dev.architectury.extensions.network.EntitySpawnExtension}
      * to load / save additional data to the client.
      *
      * @param entity The entity which should be spawned.

--- a/common/src/main/java/dev/architectury/networking/NetworkManager.java
+++ b/common/src/main/java/dev/architectury/networking/NetworkManager.java
@@ -98,6 +98,9 @@ public final class NetworkManager {
      * Easy to use utility method to create an entity spawn packet.
      * This packet is needed everytime any mod adds a non-living entity.
      * The entity should override {@link Entity#getAddEntityPacket()} to point to this method!
+     * <p>
+     * Additionally, entities may extend {@link dev.architectury.extensions.network.EntitySpawnExtension}
+     * to load / save additional data to the client.
      *
      * @param entity The entity which should be spawned.
      * @return The ready to use packet to spawn the entity on the client.

--- a/fabric/src/main/java/dev/architectury/networking/fabric/SpawnEntityPacket.java
+++ b/fabric/src/main/java/dev/architectury/networking/fabric/SpawnEntityPacket.java
@@ -19,6 +19,7 @@
 
 package dev.architectury.networking.fabric;
 
+import dev.architectury.extensions.network.EntitySpawnExtension;
 import dev.architectury.networking.NetworkManager;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -55,6 +56,9 @@ public class SpawnEntityPacket {
         buffer.writeDouble(deltaMovement.x);
         buffer.writeDouble(deltaMovement.y);
         buffer.writeDouble(deltaMovement.z);
+        if (entity instanceof EntitySpawnExtension ext) {
+            ext.saveAdditionalSpawnData(buffer);
+        }
         return NetworkManager.toPacket(NetworkManager.s2c(), PACKET_ID, buffer);
     }
     
@@ -98,6 +102,9 @@ public class SpawnEntityPacket {
                 entity.absMoveTo(x, y, z, xRot, yRot);
                 entity.setYHeadRot(yHeadRot);
                 entity.setYBodyRot(yHeadRot);
+                if (entity instanceof EntitySpawnExtension ext) {
+                    ext.loadAdditionalSpawnData(buf);
+                }
                 Minecraft.getInstance().level.putNonPlayerEntity(id, entity);
                 entity.lerpMotion(deltaX, deltaY, deltaZ);
             });

--- a/forge/src/main/java/dev/architectury/mixin/forge/MixinEntitySpawnExtension.java
+++ b/forge/src/main/java/dev/architectury/mixin/forge/MixinEntitySpawnExtension.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.mixin.forge;
+
+import dev.architectury.extensions.network.EntitySpawnExtension;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.entity.IEntityAdditionalSpawnData;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(EntitySpawnExtension.class)
+public interface MixinEntitySpawnExtension extends IEntityAdditionalSpawnData {
+    @Override
+    default void writeSpawnData(FriendlyByteBuf buf) {
+        ((EntitySpawnExtension) this).saveAdditionalSpawnData(buf);
+    }
+    
+    @Override
+    default void readSpawnData(FriendlyByteBuf buf) {
+        ((EntitySpawnExtension) this).loadAdditionalSpawnData(buf);
+    }
+}

--- a/forge/src/main/resources/architectury.mixins.json
+++ b/forge/src/main/resources/architectury.mixins.json
@@ -9,6 +9,7 @@
   ],
   "mixins": [
     "MixinChunkSerializer",
+    "MixinEntitySpawnExtension",
     "MixinFallingBlockEntity",
     "MixinItemExtension",
     "MixinRegistryEntry",


### PR DESCRIPTION
Adds `EntitySpawnExtension` that works like `IEntityAdditionalSpawnData` from forge, allowing entities to send extra data across to clients.

{Test Mod Pending}