### PR TITLE
Backported #137 PR to 1.16 fabric: Fixed PlayerAttackInvoker mixing loading crash on server side (#137)

### DIFF
--- a/fabric/src/main/java/me/shedaniel/architectury/mixin/fabric/client/ClientPlayerAttackInvoker.java
+++ b/fabric/src/main/java/me/shedaniel/architectury/mixin/fabric/client/ClientPlayerAttackInvoker.java
@@ -16,10 +16,11 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-
-package me.shedaniel.architectury.mixin.fabric;
+package me.shedaniel.architectury.mixin.fabric.client;
 
 import me.shedaniel.architectury.event.events.EntityEvent;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.player.RemotePlayer;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
@@ -29,8 +30,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = {Player.class})
-public class PlayerAttackInvoker {
+@Mixin(value = {LocalPlayer.class, RemotePlayer.class})
+public class ClientPlayerAttackInvoker {
     @Inject(method = "hurt", at = @At("HEAD"), cancellable = true)
     private void hurt(DamageSource damageSource, float f, CallbackInfoReturnable<Boolean> cir) {
         if (EntityEvent.LIVING_ATTACK.invoker().attack((LivingEntity) (Object) this, damageSource, f) == InteractionResult.FAIL && (Object) this instanceof Player) {

--- a/fabric/src/main/resources/architectury.mixins.json
+++ b/fabric/src/main/resources/architectury.mixins.json
@@ -16,7 +16,8 @@
     "client.MixinMouseHandler",
     "client.MixinMultiPlayerGameMode",
     "client.MixinScreen",
-    "client.MixinTextureAtlas"
+    "client.MixinTextureAtlas",
+    "client.ClientPlayerAttackInvoker"
   ],
   "mixins": [
     "ExplosionPreInvoker",


### PR DESCRIPTION
Backported #137 PR to 1.16 fabric:
Fixed PlayerAttackInvoker mixing loading crash on server side (#137)

As noted by [Itsmeow](https://github.com/architectury/architectury-api/pull/137#issuecomment-1000787305) the 1.16 did not receive the change that would fix the server side warning from a client mixin load attempt.

**Note:** 1.16 branch crashes due to broken fabric loader <0.11/api <0.42 dependencies since transitive accessWidener was backported on 0a64ecda1d14f60ca71afec5afb3606bee275d58. 
This problem might be related to #151.
This PR should only be merged once this issue is fixed as it impedes all testing for client/server execution. 

Signed-off-by: apple <davidalb97@hotmail.com>