### PR TITLE
Fix particle factory registration for Forge to register at the correc…

### DIFF
--- a/common/src/main/java/dev/architectury/event/events/client/ClientParticleFactoryRegisterEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/client/ClientParticleFactoryRegisterEvent.java
@@ -1,0 +1,17 @@
+package dev.architectury.event.events.client;
+
+import dev.architectury.event.Event;
+import dev.architectury.event.EventFactory;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public interface ClientParticleFactoryRegisterEvent {
+    /**
+     * Registers Particle Factory on the client.
+     * <p>
+     * <p>
+     * see Forge's {@code ParticleFactoryRegisterEvent}
+     */
+    Event<Runnable> REGISTER = EventFactory.createLoop();
+}

--- a/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplClient.java
+++ b/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplClient.java
@@ -328,5 +328,10 @@ public class EventHandlerImplClient {
         public static void event(RegisterShadersEvent event) {
             ClientReloadShadersEvent.EVENT.invoker().reload(event.getResourceManager(), event::registerShader);
         }
+        
+        @SubscribeEvent(priority = EventPriority.HIGH)
+        public static void event(ParticleFactoryRegisterEvent event) {
+            ClientParticleFactoryRegisterEvent.REGISTER.invoker().run();
+        }
     }
 }

--- a/testmod-common/src/main/java/dev/architectury/test/TestMod.java
+++ b/testmod-common/src/main/java/dev/architectury/test/TestMod.java
@@ -20,6 +20,7 @@
 package dev.architectury.test;
 
 import dev.architectury.event.events.client.ClientLifecycleEvent;
+import dev.architectury.event.events.client.ClientTickEvent;
 import dev.architectury.registry.client.level.entity.EntityRendererRegistry;
 import dev.architectury.test.debug.ConsoleMessageSink;
 import dev.architectury.test.debug.MessageSink;
@@ -63,6 +64,7 @@ public class TestMod {
         public static void initializeClient() {
             ClientLifecycleEvent.CLIENT_STARTED.register((client) -> SINK.accept("Client started!"));
             ClientLifecycleEvent.CLIENT_STOPPING.register((client) -> SINK.accept("Client stopping!"));
+            ClientTickEvent.CLIENT_LEVEL_POST.register(level -> level.addParticle(TestParticles.TEST_PARTICLE.get(), 0, 0, 0, 0, 0, 0));
             TestKeybinds.initialize();
             TestModNet.initializeClient();
             EntityRendererRegistry.register(() -> TestEntity.TYPE, context ->

--- a/testmod-common/src/main/java/dev/architectury/test/particle/TestParticles.java
+++ b/testmod-common/src/main/java/dev/architectury/test/particle/TestParticles.java
@@ -20,6 +20,7 @@
 package dev.architectury.test.particle;
 
 import dev.architectury.event.events.client.ClientLifecycleEvent;
+import dev.architectury.event.events.client.ClientParticleFactoryRegisterEvent;
 import dev.architectury.platform.Platform;
 import dev.architectury.registry.client.particle.ParticleProviderRegistry;
 import dev.architectury.registry.registries.DeferredRegister;
@@ -40,9 +41,7 @@ public class TestParticles {
     public static void initialize() {
         PARTICLE_TYPES.register();
         if (Platform.getEnvironment() == Env.CLIENT) {
-            ClientLifecycleEvent.CLIENT_SETUP.register(instance -> {
-                    ParticleProviderRegistry.register(TEST_PARTICLE.get(), HeartParticle.Provider::new);
-            });
+            ClientLifecycleEvent.CLIENT_SETUP.register(instance -> ParticleProviderRegistry.register(TEST_PARTICLE.get(), HeartParticle.Provider::new));
         }
     }
 }

--- a/testmod-common/src/main/resources/assets/architectury_test/particles/test_particle.json
+++ b/testmod-common/src/main/resources/assets/architectury_test/particles/test_particle.json
@@ -1,0 +1,5 @@
+{
+  "textures": [
+    "architectury_test:test_particle"
+  ]
+}


### PR DESCRIPTION
…t time

- Added Architectury event to hook into Forge's ParticleFactoryRegistryEvent.
- Added resource test_particle json required for particles
- Removed deferred registration in Forge ParticleProviderRegistry impl, replaced with registry to proper forge event
- Removed EventBus and SubscribeEvent annotation which did not work (was not registered on the event bus properly)
- Fabric Impl untouched, works as it should (now that test_particle.json exists

![2022-02-08_20 58 03](https://user-images.githubusercontent.com/30945719/153116167-33076058-26b1-4b3e-ae7a-360499005b18.png)
)