### PR TITLE
Fixed EntitySpawnExtension buffer being unable to be read from, #208

### DIFF
--- a/fabric/src/main/java/dev/architectury/networking/fabric/SpawnEntityPacket.java
+++ b/fabric/src/main/java/dev/architectury/networking/fabric/SpawnEntityPacket.java
@@ -107,6 +107,7 @@ public class SpawnEntityPacket {
                 if (entity instanceof EntitySpawnExtension ext) {
                     ext.loadAdditionalSpawnData(extBuf);
                 }
+                extBuf.release();
                 Minecraft.getInstance().level.putNonPlayerEntity(id, entity);
                 entity.lerpMotion(deltaX, deltaY, deltaZ);
             });

--- a/fabric/src/main/java/dev/architectury/networking/fabric/SpawnEntityPacket.java
+++ b/fabric/src/main/java/dev/architectury/networking/fabric/SpawnEntityPacket.java
@@ -21,6 +21,7 @@ package dev.architectury.networking.fabric;
 
 import dev.architectury.extensions.network.EntitySpawnExtension;
 import dev.architectury.networking.NetworkManager;
+import io.netty.buffer.Unpooled;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
@@ -84,6 +85,7 @@ public class SpawnEntityPacket {
             var deltaX = buf.readDouble();
             var deltaY = buf.readDouble();
             var deltaZ = buf.readDouble();
+            var extBuf = new FriendlyByteBuf(Unpooled.buffer().writeBytes(buf));
             context.queue(() -> {
                 var entityType = Registry.ENTITY_TYPE.byId(entityTypeId);
                 if (entityType == null) {
@@ -103,7 +105,7 @@ public class SpawnEntityPacket {
                 entity.setYHeadRot(yHeadRot);
                 entity.setYBodyRot(yHeadRot);
                 if (entity instanceof EntitySpawnExtension ext) {
-                    ext.loadAdditionalSpawnData(buf);
+                    ext.loadAdditionalSpawnData(extBuf);
                 }
                 Minecraft.getInstance().level.putNonPlayerEntity(id, entity);
                 entity.lerpMotion(deltaX, deltaY, deltaZ);


### PR DESCRIPTION
The buffer exception mentioned in #208 suggests that the buffer used for the packet is marked as having no further references for garbage collection by the time the context block executes. The solution is to evacuate the remaining bytes from the buffer while the reference is held and letting this new buffer be consumed in the context block.

Closes #208 