### PR TITLE
Fix RegistrySupplier#listen and ArchitecturySpawnEggItem

### DIFF
--- a/common/src/main/java/dev/architectury/core/item/ArchitecturySpawnEggItem.java
+++ b/common/src/main/java/dev/architectury/core/item/ArchitecturySpawnEggItem.java
@@ -19,9 +19,11 @@
 
 package dev.architectury.core.item;
 
+import dev.architectury.registry.registries.Registries;
 import dev.architectury.registry.registries.RegistrySupplier;
 import net.minecraft.core.BlockSource;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Registry;
 import net.minecraft.core.dispenser.DefaultDispenseItemBehavior;
 import net.minecraft.core.dispenser.DispenseItemBehavior;
 import net.minecraft.nbt.CompoundTag;
@@ -74,8 +76,14 @@ public class ArchitecturySpawnEggItem extends SpawnEggItem {
         this.entityType = Objects.requireNonNull(entityType, "entityType");
         SpawnEggItem.BY_ID.remove(null);
         entityType.listen(type -> {
+            LOGGER.debug("Registering spawn egg {} for {}", Objects.toString(Registries.getId(this, Registry.ITEM_REGISTRY)),
+                    Objects.toString(Registries.getId(type, Registry.ENTITY_TYPE_REGISTRY)));
             SpawnEggItem.BY_ID.put(type, this);
             this.defaultType = type;
+            
+            if (dispenseItemBehavior != null) {
+                DispenserBlock.registerBehavior(this, dispenseItemBehavior);
+            }
         });
     }
     

--- a/common/src/main/java/dev/architectury/registry/client/level/entity/EntityRendererRegistry.java
+++ b/common/src/main/java/dev/architectury/registry/client/level/entity/EntityRendererRegistry.java
@@ -34,7 +34,7 @@ public final class EntityRendererRegistry {
     }
     
     @ExpectPlatform
-    public static <T extends Entity> void register(Supplier<EntityType<? extends T>> type, EntityRendererProvider<T> provider) {
+    public static <T extends Entity> void register(Supplier<? extends EntityType<? extends T>> type, EntityRendererProvider<T> provider) {
         throw new AssertionError();
     }
 }

--- a/fabric/src/main/java/dev/architectury/registry/client/level/entity/fabric/EntityRendererRegistryImpl.java
+++ b/fabric/src/main/java/dev/architectury/registry/client/level/entity/fabric/EntityRendererRegistryImpl.java
@@ -27,7 +27,7 @@ import net.minecraft.world.entity.EntityType;
 import java.util.function.Supplier;
 
 public class EntityRendererRegistryImpl {
-    public static <T extends Entity> void register(Supplier<EntityType<? extends T>> type, EntityRendererProvider<T> provider) {
+    public static <T extends Entity> void register(Supplier<? extends EntityType<? extends T>> type, EntityRendererProvider<T> provider) {
         EntityRendererRegistry.register(type.get(), provider);
     }
 }

--- a/fabric/src/main/java/dev/architectury/registry/registries/fabric/RegistriesImpl.java
+++ b/fabric/src/main/java/dev/architectury/registry/registries/fabric/RegistriesImpl.java
@@ -278,9 +278,8 @@ public class RegistriesImpl {
         
         @Override
         public void listen(ResourceLocation id, Consumer<T> callback) {
-            T value = get(id);
-            if (value != null) {
-                callback.accept(value);
+            if (contains(id)) {
+                callback.accept(get(id));
             } else {
                 RegistriesImpl.listen(key(), id, callback);
             }

--- a/forge/src/main/java/dev/architectury/registry/client/level/entity/forge/EntityRendererRegistryImpl.java
+++ b/forge/src/main/java/dev/architectury/registry/client/level/entity/forge/EntityRendererRegistryImpl.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 public class EntityRendererRegistryImpl {
     private static final Map<Supplier<EntityType<?>>, EntityRendererProvider<?>> RENDERERS = new ConcurrentHashMap<>();
     
-    public static <T extends Entity> void register(Supplier<EntityType<? extends T>> type, EntityRendererProvider<T> factory) {
+    public static <T extends Entity> void register(Supplier<? extends EntityType<? extends T>> type, EntityRendererProvider<T> factory) {
         RENDERERS.put((Supplier<EntityType<?>>) (Supplier<? extends EntityType<?>>) type, factory);
     }
     

--- a/forge/src/main/java/dev/architectury/registry/registries/forge/RegistriesImpl.java
+++ b/forge/src/main/java/dev/architectury/registry/registries/forge/RegistriesImpl.java
@@ -489,9 +489,8 @@ public class RegistriesImpl {
         
         @Override
         public void listen(ResourceLocation id, Consumer<T> callback) {
-            T value = get(id);
-            if (value != null) {
-                callback.accept(value);
+            if (contains(id)) {
+                callback.accept(get(id));
             } else {
                 RegistriesImpl.listen(key(), id, callback, true);
             }
@@ -680,9 +679,8 @@ public class RegistriesImpl {
         
         @Override
         public void listen(ResourceLocation id, Consumer<T> callback) {
-            T value = get(id);
-            if (value != null) {
-                callback.accept(value);
+            if (contains(id)) {
+                callback.accept(get(id));
             } else {
                 RegistriesImpl.listen(key(), id, callback, false);
             }

--- a/testmod-common/src/main/java/dev/architectury/test/TestMod.java
+++ b/testmod-common/src/main/java/dev/architectury/test/TestMod.java
@@ -38,7 +38,9 @@ import dev.architectury.utils.Env;
 import dev.architectury.utils.EnvExecutor;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.renderer.entity.CowRenderer;
 import net.minecraft.client.renderer.entity.PigRenderer;
+import net.minecraft.world.entity.animal.Cow;
 
 public class TestMod {
     public static final MessageSink SINK = EnvExecutor.getEnvSpecific(() -> ClientOverlayMessageSink::new, () -> ConsoleMessageSink::new);
@@ -64,7 +66,8 @@ public class TestMod {
             ClientLifecycleEvent.CLIENT_STOPPING.register((client) -> SINK.accept("Client stopping!"));
             TestKeybinds.initialize();
             TestModNet.initializeClient();
-            EntityRendererRegistry.register(() -> TestEntity.TYPE, PigRenderer::new);
+            EntityRendererRegistry.register(TestRegistries.TEST_ENTITY, CowRenderer::new);
+            EntityRendererRegistry.register(TestRegistries.TEST_ENTITY_2, CowRenderer::new);
         }
     }
 }

--- a/testmod-common/src/main/java/dev/architectury/test/entity/TestEntity.java
+++ b/testmod-common/src/main/java/dev/architectury/test/entity/TestEntity.java
@@ -19,17 +19,21 @@
 
 package dev.architectury.test.entity;
 
+import com.google.common.base.Suppliers;
 import dev.architectury.networking.NetworkManager;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
-import net.minecraft.world.entity.animal.Pig;
+import net.minecraft.world.entity.animal.Cow;
 import net.minecraft.world.level.Level;
 
-public class TestEntity extends Pig {
-    public static final EntityType<TestEntity> TYPE = EntityType.Builder.of(TestEntity::new, MobCategory.MISC).sized(0.98F, 0.7F).clientTrackingRange(8).build("test_entity");
+import java.util.function.Supplier;
+
+public class TestEntity extends Cow {
+    public static final Supplier<EntityType<TestEntity>> TYPE = Suppliers.memoize(() -> EntityType.Builder.of(TestEntity::new, MobCategory.MISC).sized(0.98F, 0.7F).clientTrackingRange(8).build("test_entity"));
+    public static final Supplier<EntityType<TestEntity>> TYPE_2 = Suppliers.memoize(() -> EntityType.Builder.of(TestEntity::new, MobCategory.MISC).sized(0.98F, 0.7F).clientTrackingRange(8).build("test_entity_2"));
     
-    public TestEntity(EntityType<? extends Pig> entityType, Level level) {
+    public TestEntity(EntityType<? extends Cow> entityType, Level level) {
         super(entityType, level);
     }
     

--- a/testmod-common/src/main/java/dev/architectury/test/registry/TestRegistries.java
+++ b/testmod-common/src/main/java/dev/architectury/test/registry/TestRegistries.java
@@ -37,7 +37,6 @@ import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.animal.Pig;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
@@ -77,6 +76,9 @@ public class TestRegistries {
     public static final RegistrySupplier<Item> TEST_SPAWN_EGG = ITEMS.register("test_spawn_egg", () ->
             new ArchitecturySpawnEggItem(TestRegistries.TEST_ENTITY, 0xFF000000, 0xFFFFFFFF,
                     new Item.Properties().tab(TestCreativeTabs.TEST_TAB)));
+    public static final RegistrySupplier<Item> TEST_SPAWN_EGG_2 = ITEMS.register("test_spawn_egg_2", () ->
+            new ArchitecturySpawnEggItem(TestRegistries.TEST_ENTITY_2, 0xFFFFFFFF, 0xFF000000,
+                    new Item.Properties().tab(TestCreativeTabs.TEST_TAB)));
     
     public static final RegistrySupplier<Block> TEST_BLOCK = BLOCKS.register("test_block", () ->
             new Block(BlockProperties.copy(Blocks.STONE)));
@@ -94,7 +96,8 @@ public class TestRegistries {
     public static final RegistrySupplier<Item> COLLISION_BLOCK_ITEM = ITEMS.register("collision_block", () ->
             new BlockItem(COLLISION_BLOCK.get(), new Item.Properties().tab(TestCreativeTabs.TEST_TAB)));
     
-    public static final RegistrySupplier<EntityType<TestEntity>> TEST_ENTITY = ENTITY_TYPES.register("test_entity", () -> TestEntity.TYPE);
+    public static final RegistrySupplier<EntityType<TestEntity>> TEST_ENTITY = ENTITY_TYPES.register("test_entity", TestEntity.TYPE);
+    public static final RegistrySupplier<EntityType<TestEntity>> TEST_ENTITY_2 = ENTITY_TYPES.register("test_entity_2", TestEntity.TYPE_2);
     
     public static final RegistrySupplier<RecipeSerializer<CustomRecipe>> TEST_SERIALIZER = RECIPE_SERIALIZERS.register("test_serializer", TestRecipeSerializer::new);
     
@@ -112,7 +115,8 @@ public class TestRegistries {
         ENTITY_TYPES.register();
         RECIPE_TYPES.register();
         RECIPE_SERIALIZERS.register();
-        EntityAttributeRegistry.register(TEST_ENTITY, Pig::createAttributes);
+        EntityAttributeRegistry.register(TEST_ENTITY, TestEntity::createAttributes);
+        EntityAttributeRegistry.register(TEST_ENTITY_2, TestEntity::createAttributes);
         TEST_BLOCK_ITEM.listen(item -> {
             System.out.println("Registered item!");
         });

--- a/testmod-common/src/main/resources/assets/architectury_test/models/item/test_spawn_egg_2.json
+++ b/testmod-common/src/main/resources/assets/architectury_test/models/item/test_spawn_egg_2.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:item/template_spawn_egg"
+}


### PR DESCRIPTION
- Fix RegistrySupplier.listen not working (they immediately resolve and gets the default value from the registry)
- Fix ArchitecturySpawnEggItem's dispenser action & colors