### PR TITLE
Close #236

### DIFF
--- a/common/src/main/java/dev/architectury/registry/level/block/BlockFlammabilityRegistry.java
+++ b/common/src/main/java/dev/architectury/registry/level/block/BlockFlammabilityRegistry.java
@@ -57,30 +57,6 @@ public final class BlockFlammabilityRegistry {
     }
     
     /**
-     * Registers the flammability for the given blocks for all fire blocks.
-     *
-     * @param burnOdds        the burn odds
-     * @param flameOdds       the flame odds
-     * @param flammableBlocks the flammable blocks
-     */
-    @ExpectPlatform
-    public static void registerAll(int burnOdds, int flameOdds, Block... flammableBlocks) {
-        throw new AssertionError();
-    }
-    
-    /**
-     * Registers the flammability for a given block tag for all fire blocks.
-     *
-     * @param burnOdds        the burn odds
-     * @param flameOdds       the flame odds
-     * @param flammableBlocks the flammable block tag
-     */
-    @ExpectPlatform
-    public static void registerAll(int burnOdds, int flameOdds, TagKey<Block> flammableBlocks) {
-        throw new AssertionError();
-    }
-    
-    /**
      * Registers the flammability for the given blocks for a given fire block.
      *
      * @param fireBlock       the specific fire block

--- a/common/src/main/java/dev/architectury/registry/level/block/BlockFlammabilityRegistry.java
+++ b/common/src/main/java/dev/architectury/registry/level/block/BlockFlammabilityRegistry.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.registry.level.block;
+
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+public final class BlockFlammabilityRegistry {
+    /**
+     * Gets the burn odds for the given block.
+     *
+     * @param level     the level
+     * @param state     the block state
+     * @param pos       the position of the block
+     * @param direction the direction of where the fire is coming from
+     * @return the burn odds
+     */
+    @ExpectPlatform
+    public static int getBurnOdds(BlockGetter level, BlockState state, BlockPos pos, Direction direction) {
+        throw new AssertionError();
+    }
+    
+    /**
+     * Gets the flame odds for the given block.
+     *
+     * @param level     the level
+     * @param state     the block state
+     * @param pos       the position of the block
+     * @param direction the direction of where the fire is spreading from
+     * @return the flame odds
+     */
+    @ExpectPlatform
+    public static int getFlameOdds(BlockGetter level, BlockState state, BlockPos pos, Direction direction) {
+        throw new AssertionError();
+    }
+    
+    /**
+     * Registers the flammability for the given blocks for all fire blocks.
+     *
+     * @param burnOdds        the burn odds
+     * @param flameOdds       the flame odds
+     * @param flammableBlocks the flammable blocks
+     */
+    @ExpectPlatform
+    public static void registerAll(int burnOdds, int flameOdds, Block... flammableBlocks) {
+        throw new AssertionError();
+    }
+    
+    /**
+     * Registers the flammability for a given block tag for all fire blocks.
+     *
+     * @param burnOdds        the burn odds
+     * @param flameOdds       the flame odds
+     * @param flammableBlocks the flammable block tag
+     */
+    @ExpectPlatform
+    public static void registerAll(int burnOdds, int flameOdds, TagKey<Block> flammableBlocks) {
+        throw new AssertionError();
+    }
+    
+    /**
+     * Registers the flammability for the given blocks for a given fire block.
+     *
+     * @param fireBlock       the specific fire block
+     * @param burnOdds        the burn odds
+     * @param flameOdds       the flame odds
+     * @param flammableBlocks the flammable blocks
+     */
+    @ExpectPlatform
+    public static void register(Block fireBlock, int burnOdds, int flameOdds, Block... flammableBlocks) {
+        throw new AssertionError();
+    }
+    
+    /**
+     * Registers the flammability for a given block tag for a given fire block.
+     *
+     * @param fireBlock       the specific fire block
+     * @param burnOdds        the burn odds
+     * @param flameOdds       the flame odds
+     * @param flammableBlocks the flammable block tag
+     */
+    @ExpectPlatform
+    public static void register(Block fireBlock, int burnOdds, int flameOdds, TagKey<Block> flammableBlocks) {
+        throw new AssertionError();
+    }
+}

--- a/fabric/src/main/java/dev/architectury/registry/level/block/fabric/BlockFlammabilityRegistryImpl.java
+++ b/fabric/src/main/java/dev/architectury/registry/level/block/fabric/BlockFlammabilityRegistryImpl.java
@@ -53,18 +53,6 @@ public class BlockFlammabilityRegistryImpl {
         }
     }
     
-    public static void registerAll(int burnOdds, int flameOdds, Block... flammableBlocks) {
-        FlammableBlockRegistry registry = FlammableBlockRegistry.getDefaultInstance();
-        for (Block block : flammableBlocks) {
-            registry.add(block, burnOdds, flameOdds);
-        }
-    }
-    
-    public static void registerAll(int burnOdds, int flameOdds, TagKey<Block> flammableBlocks) {
-        FlammableBlockRegistry registry = FlammableBlockRegistry.getDefaultInstance();
-        registry.add(flammableBlocks, burnOdds, flameOdds);
-    }
-    
     public static void register(Block fireBlock, int burnOdds, int flameOdds, Block... flammableBlocks) {
         FlammableBlockRegistry registry = FlammableBlockRegistry.getInstance(fireBlock);
         for (Block block : flammableBlocks) {

--- a/fabric/src/main/java/dev/architectury/registry/level/block/fabric/BlockFlammabilityRegistryImpl.java
+++ b/fabric/src/main/java/dev/architectury/registry/level/block/fabric/BlockFlammabilityRegistryImpl.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.registry.level.block.fabric;
+
+import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.FireBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class BlockFlammabilityRegistryImpl {
+    public static int getBurnOdds(BlockGetter level, BlockState state, BlockPos pos, Direction direction) {
+        BlockState fireState = level.getBlockState(pos.relative(direction));
+        
+        if (fireState.getBlock() instanceof FireBlock fireBlock) {
+            FlammableBlockRegistry.Entry entry = FlammableBlockRegistry.getInstance(fireBlock).get(state.getBlock());
+            return entry.getBurnChance();
+        } else {
+            FlammableBlockRegistry.Entry entry = FlammableBlockRegistry.getDefaultInstance().get(state.getBlock());
+            return entry.getBurnChance();
+        }
+    }
+    
+    public static int getFlameOdds(BlockGetter level, BlockState state, BlockPos pos, Direction direction) {
+        BlockState fireState = level.getBlockState(pos.relative(direction));
+        
+        if (fireState.getBlock() instanceof FireBlock fireBlock) {
+            FlammableBlockRegistry.Entry entry = FlammableBlockRegistry.getInstance(fireBlock).get(state.getBlock());
+            return entry.getSpreadChance();
+        } else {
+            FlammableBlockRegistry.Entry entry = FlammableBlockRegistry.getDefaultInstance().get(state.getBlock());
+            return entry.getSpreadChance();
+        }
+    }
+    
+    public static void registerAll(int burnOdds, int flameOdds, Block... flammableBlocks) {
+        FlammableBlockRegistry registry = FlammableBlockRegistry.getDefaultInstance();
+        for (Block block : flammableBlocks) {
+            registry.add(block, burnOdds, flameOdds);
+        }
+    }
+    
+    public static void registerAll(int burnOdds, int flameOdds, TagKey<Block> flammableBlocks) {
+        FlammableBlockRegistry registry = FlammableBlockRegistry.getDefaultInstance();
+        registry.add(flammableBlocks, burnOdds, flameOdds);
+    }
+    
+    public static void register(Block fireBlock, int burnOdds, int flameOdds, Block... flammableBlocks) {
+        FlammableBlockRegistry registry = FlammableBlockRegistry.getInstance(fireBlock);
+        for (Block block : flammableBlocks) {
+            registry.add(block, burnOdds, flameOdds);
+        }
+    }
+    
+    public static void register(Block fireBlock, int burnOdds, int flameOdds, TagKey<Block> flammableBlocks) {
+        FlammableBlockRegistry registry = FlammableBlockRegistry.getInstance(fireBlock);
+        registry.add(flammableBlocks, burnOdds, flameOdds);
+    }
+}

--- a/forge/src/main/java/dev/architectury/mixin/forge/MixinIForgeBlock.java
+++ b/forge/src/main/java/dev/architectury/mixin/forge/MixinIForgeBlock.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.mixin.forge;
+
+import net.minecraftforge.common.extensions.IForgeBlock;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(IForgeBlock.class)
+public interface MixinIForgeBlock {
+}

--- a/forge/src/main/java/dev/architectury/registry/level/block/forge/BlockFlammabilityRegistryImpl.java
+++ b/forge/src/main/java/dev/architectury/registry/level/block/forge/BlockFlammabilityRegistryImpl.java
@@ -1,0 +1,186 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.registry.level.block.forge;
+
+import dev.architectury.registry.ReloadListenerRegistry;
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.tags.TagKey;
+import net.minecraft.util.Unit;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.FireBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class BlockFlammabilityRegistryImpl {
+    public static int getBurnOdds(BlockGetter level, BlockState state, BlockPos pos, Direction direction) {
+        return state.getFlammability(level, pos, direction);
+    }
+    
+    public static int getFlameOdds(BlockGetter level, BlockState state, BlockPos pos, Direction direction) {
+        return state.getFireSpreadSpeed(level, pos, direction);
+    }
+    
+    private static final Reference2ObjectMap<Block, Data> DATAS = new Reference2ObjectOpenHashMap<>();
+    
+    private static Data getGlobalData() {
+        return DATAS.computeIfAbsent(Blocks.AIR, $ -> new Data());
+    }
+    
+    private static Data getData(Block fireBlock) {
+        if (fireBlock instanceof FireBlock) {
+            return DATAS.computeIfAbsent(fireBlock, $ -> new Data());
+        } else {
+            throw new IllegalArgumentException("Expected fire block, got " + fireBlock);
+        }
+    }
+    
+    private static class Data {
+        private final Reference2IntMap<Block> burnOdds = new Reference2IntOpenHashMap<>();
+        private final Reference2IntMap<Block> flameOdds = new Reference2IntOpenHashMap<>();
+        private final Reference2IntMap<TagKey<Block>> burnTagOdds = new Reference2IntOpenHashMap<>();
+        private final Reference2IntMap<TagKey<Block>> flameTagOdds = new Reference2IntOpenHashMap<>();
+        private final Reference2IntMap<Block> burnCollectedOdds = new Reference2IntOpenHashMap<>();
+        private final Reference2IntMap<Block> flameCollectedOdds = new Reference2IntOpenHashMap<>();
+        
+        int getBurnOdds(Block block) {
+            return burnCollectedOdds.getOrDefault(block, -1);
+        }
+        
+        int getFlameOdds(Block block) {
+            return flameCollectedOdds.getOrDefault(block, -1);
+        }
+    }
+    
+    static {
+        ReloadListenerRegistry.register(PackType.SERVER_DATA, (preparationBarrier, resourceManager, profilerFiller, profiler2, executor, executor2) -> {
+            return preparationBarrier.wait(Unit.INSTANCE).thenRunAsync(() -> {
+                profiler2.startTick();
+                profiler2.push("handle_arch_flammables");
+                for (Data data : DATAS.values()) {
+                    data.burnCollectedOdds.clear();
+                    data.flameCollectedOdds.clear();
+                    data.burnCollectedOdds.putAll(data.burnOdds);
+                    data.flameCollectedOdds.putAll(data.flameOdds);
+                    
+                    for (Reference2IntMap.Entry<TagKey<Block>> entry : data.burnTagOdds.reference2IntEntrySet()) {
+                        for (Holder<Block> holder : Registry.BLOCK.getTagOrEmpty(entry.getKey())) {
+                            data.burnCollectedOdds.put(holder.value(), entry.getIntValue());
+                        }
+                    }
+                    
+                    for (Reference2IntMap.Entry<TagKey<Block>> entry : data.flameTagOdds.reference2IntEntrySet()) {
+                        for (Holder<Block> holder : Registry.BLOCK.getTagOrEmpty(entry.getKey())) {
+                            data.flameCollectedOdds.put(holder.value(), entry.getIntValue());
+                        }
+                    }
+                }
+                profiler2.pop();
+                profiler2.endTick();
+            }, executor2);
+        });
+    }
+    
+    public static void registerAll(int burnOdds, int flameOdds, Block... flammableBlocks) {
+        Data data = getGlobalData();
+        
+        for (Block block : flammableBlocks) {
+            data.burnOdds.put(block, burnOdds);
+            data.flameOdds.put(block, burnOdds);
+        }
+    }
+    
+    public static void registerAll(int burnOdds, int flameOdds, TagKey<Block> flammableBlocks) {
+        Data data = getGlobalData();
+        
+        data.burnTagOdds.put(flammableBlocks, burnOdds);
+        data.flameTagOdds.put(flammableBlocks, burnOdds);
+    }
+    
+    public static void register(Block fireBlock, int burnOdds, int flameOdds, Block... flammableBlocks) {
+        Data data = getData(fireBlock);
+        
+        for (Block block : flammableBlocks) {
+            data.burnOdds.put(block, burnOdds);
+            data.flameOdds.put(block, burnOdds);
+        }
+    }
+    
+    public static void register(Block fireBlock, int burnOdds, int flameOdds, TagKey<Block> flammableBlocks) {
+        Data data = getData(fireBlock);
+        
+        data.burnTagOdds.put(flammableBlocks, burnOdds);
+        data.flameTagOdds.put(flammableBlocks, burnOdds);
+    }
+    
+    public static int handleBurnOddsHook(int previousValue, BlockState state, BlockGetter level, BlockPos pos, Direction direction) {
+        BlockState fireState = level.getBlockState(pos.relative(direction));
+        
+        if (fireState.getBlock() instanceof FireBlock fireBlock) {
+            int odds = getData(fireBlock).getBurnOdds(state.getBlock());
+            if (odds >= 0) {
+                return odds;
+            }
+        } else {
+            int odds = getData(Blocks.FIRE).getBurnOdds(state.getBlock());
+            if (odds >= 0) {
+                return odds;
+            }
+        }
+        
+        int odds = getGlobalData().getBurnOdds(state.getBlock());
+        if (odds >= 0) {
+            return odds;
+        }
+        
+        return previousValue;
+    }
+    
+    public static int handleSpreadOddsHook(int previousValue, BlockState state, BlockGetter level, BlockPos pos, Direction direction) {
+        BlockState fireState = level.getBlockState(pos.relative(direction));
+        
+        if (fireState.getBlock() instanceof FireBlock fireBlock) {
+            int odds = getData(fireBlock).getFlameOdds(state.getBlock());
+            if (odds >= 0) {
+                return odds;
+            }
+        } else {
+            int odds = getData(Blocks.FIRE).getFlameOdds(state.getBlock());
+            if (odds >= 0) {
+                return odds;
+            }
+        }
+        
+        int odds = getGlobalData().getFlameOdds(state.getBlock());
+        if (odds >= 0) {
+            return odds;
+        }
+        
+        return previousValue;
+    }
+}

--- a/forge/src/main/java/dev/architectury/registry/level/block/forge/BlockFlammabilityRegistryImpl.java
+++ b/forge/src/main/java/dev/architectury/registry/level/block/forge/BlockFlammabilityRegistryImpl.java
@@ -33,7 +33,6 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.util.Unit;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.FireBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -47,10 +46,6 @@ public class BlockFlammabilityRegistryImpl {
     }
     
     private static final Reference2ObjectMap<Block, Data> DATAS = new Reference2ObjectOpenHashMap<>();
-    
-    private static Data getGlobalData() {
-        return DATAS.computeIfAbsent(Blocks.AIR, $ -> new Data());
-    }
     
     private static Data getData(Block fireBlock) {
         if (fireBlock instanceof FireBlock) {
@@ -106,22 +101,6 @@ public class BlockFlammabilityRegistryImpl {
         });
     }
     
-    public static void registerAll(int burnOdds, int flameOdds, Block... flammableBlocks) {
-        Data data = getGlobalData();
-        
-        for (Block block : flammableBlocks) {
-            data.burnOdds.put(block, burnOdds);
-            data.flameOdds.put(block, burnOdds);
-        }
-    }
-    
-    public static void registerAll(int burnOdds, int flameOdds, TagKey<Block> flammableBlocks) {
-        Data data = getGlobalData();
-        
-        data.burnTagOdds.put(flammableBlocks, burnOdds);
-        data.flameTagOdds.put(flammableBlocks, burnOdds);
-    }
-    
     public static void register(Block fireBlock, int burnOdds, int flameOdds, Block... flammableBlocks) {
         Data data = getData(fireBlock);
         
@@ -146,16 +125,6 @@ public class BlockFlammabilityRegistryImpl {
             if (odds >= 0) {
                 return odds;
             }
-        } else {
-            int odds = getData(Blocks.FIRE).getBurnOdds(state.getBlock());
-            if (odds >= 0) {
-                return odds;
-            }
-        }
-        
-        int odds = getGlobalData().getBurnOdds(state.getBlock());
-        if (odds >= 0) {
-            return odds;
         }
         
         return previousValue;
@@ -169,16 +138,6 @@ public class BlockFlammabilityRegistryImpl {
             if (odds >= 0) {
                 return odds;
             }
-        } else {
-            int odds = getData(Blocks.FIRE).getFlameOdds(state.getBlock());
-            if (odds >= 0) {
-                return odds;
-            }
-        }
-        
-        int odds = getGlobalData().getFlameOdds(state.getBlock());
-        if (odds >= 0) {
-            return odds;
         }
         
         return previousValue;

--- a/forge/src/main/resources/architectury.mixins.json
+++ b/forge/src/main/resources/architectury.mixins.json
@@ -12,6 +12,7 @@
     "MixinChunkSerializer",
     "MixinEntitySpawnExtension",
     "MixinFallingBlockEntity",
+    "MixinIForgeBlock",
     "MixinItemExtension",
     "MixinRegistryEntry",
     "MixinWorldEvent"


### PR DESCRIPTION
Implements the flammable registry to allow mods register their blocks as flammable, **this PR is currently not tested, test mod pending!**

I am not sure if the fabric flammable registry's default instance is applicable to all fire blocks, probably not, so that needs to be look into and tested as well.

I am wary of the performance issues by looking up the near by fire block, ~~but vanilla fires are already laggy~~, and I can't think of a better way to implement this.

We need to inject to an interface, thus the custom ASM we have here.