### PR TITLE
Introduce FluidBucketHooks.getFluid

### DIFF
--- a/common/src/main/java/dev/architectury/hooks/fluid/FluidBucketHooks.java
+++ b/common/src/main/java/dev/architectury/hooks/fluid/FluidBucketHooks.java
@@ -31,7 +31,6 @@ public final class FluidBucketHooks {
      * @param item the bucket item
      * @return the fluid contained in the bucket
      */
-    
     @ExpectPlatform
     public static Fluid getFluid(BucketItem item) {
         throw new AssertionError();

--- a/common/src/main/java/dev/architectury/hooks/fluid/FluidBucketHooks.java
+++ b/common/src/main/java/dev/architectury/hooks/fluid/FluidBucketHooks.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.hooks.fluid;
+
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.level.material.Fluid;
+
+public final class FluidBucketHooks {
+    /**
+     * Returns the fluid contained in the bucket.
+     * This requires special handling since forge defers the fiuid.
+     *
+     * @param item the bucket item
+     * @return the fluid contained in the bucket
+     */
+    
+    @ExpectPlatform
+    public static Fluid getFluid(BucketItem item) {
+        throw new AssertionError();
+    }
+}

--- a/fabric/src/main/java/dev/architectury/hooks/fluid/fabric/FluidBucketHooksImpl.java
+++ b/fabric/src/main/java/dev/architectury/hooks/fluid/fabric/FluidBucketHooksImpl.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.hooks.fluid.fabric;
+
+import dev.architectury.mixin.fabric.BucketItemAccessor;
+import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.level.material.Fluid;
+
+public class FluidBucketHooksImpl {
+    public static Fluid getFluid(BucketItem item) {
+        return ((BucketItemAccessor) item).getContent();
+    }
+}

--- a/fabric/src/main/java/dev/architectury/mixin/fabric/BucketItemAccessor.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/BucketItemAccessor.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.mixin.fabric;
+
+import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.level.material.Fluid;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(BucketItem.class)
+public interface BucketItemAccessor {
+    @Accessor("content")
+    Fluid getContent();
+}

--- a/fabric/src/main/resources/architectury.mixins.json
+++ b/fabric/src/main/resources/architectury.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_16",
   "minVersion": "0.7.11",
   "client": [
+    "client.ClientPlayerAttackInvoker",
     "client.MixinAbstractContainerScreen",
     "client.MixinClientLevel",
     "client.MixinClientPacketListener",
@@ -17,10 +18,10 @@
     "client.MixinMouseHandler",
     "client.MixinMultiPlayerGameMode",
     "client.MixinScreen",
-    "client.MixinTextureAtlas",
-    "client.ClientPlayerAttackInvoker"
+    "client.MixinTextureAtlas"
   ],
   "mixins": [
+    "BucketItemAccessor",
     "ExplosionPreInvoker",
     "HorseTameInvoker",
     "LivingDeathInvoker",

--- a/forge/src/main/java/dev/architectury/hooks/fluid/forge/FluidBucketHooksImpl.java
+++ b/forge/src/main/java/dev/architectury/hooks/fluid/forge/FluidBucketHooksImpl.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.hooks.fluid.forge;
+
+import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.level.material.Fluid;
+
+public class FluidBucketHooksImpl {
+    public static Fluid getFluid(BucketItem item) {
+        return item.getFluid();
+    }
+}


### PR DESCRIPTION
This requires special handling since forge defers the fiuid, and you can't AT / AW the content field of the bucket item anyways since forge uses asm to redirect calls from the field.