### PR TITLE
Make AW for `MenuType$MenuSupplier` transitive, deprecate `MenuRegistry.of`

### DIFF
--- a/common/src/main/java/dev/architectury/registry/menu/MenuRegistry.java
+++ b/common/src/main/java/dev/architectury/registry/menu/MenuRegistry.java
@@ -97,7 +97,9 @@ public final class MenuRegistry {
      * @param factory A functional interface to create the {@link MenuType} from an id (Integer) and inventory
      * @param <T>     The type of {@link AbstractContainerMenu} that handles the logic for the {@link MenuType}
      * @return The {@link MenuType} for your {@link AbstractContainerMenu}
+     * @deprecated Use the constructor directly.
      */
+    @Deprecated(forRemoval = true)
     @ExpectPlatform
     public static <T extends AbstractContainerMenu> MenuType<T> of(SimpleMenuTypeFactory<T> factory) {
         throw new AssertionError();
@@ -154,6 +156,7 @@ public final class MenuRegistry {
      *
      * @param <T> The {@link AbstractContainerMenu} type
      */
+    @Deprecated(forRemoval = true)
     @FunctionalInterface
     public interface SimpleMenuTypeFactory<T extends AbstractContainerMenu> {
         /**

--- a/common/src/main/resources/architectury.accessWidener
+++ b/common/src/main/resources/architectury.accessWidener
@@ -52,8 +52,8 @@ mutable field net/minecraft/world/level/block/state/BlockBehaviour$Properties dy
 accessible method net/minecraft/world/level/block/state/BlockBehaviour$Properties <init> (Lnet/minecraft/world/level/material/Material;Ljava/util/function/Function;)V
 transitive-accessible method net/minecraft/world/entity/player/Player closeContainer ()V
 transitive-accessible method net/minecraft/advancements/CriteriaTriggers register (Lnet/minecraft/advancements/CriterionTrigger;)Lnet/minecraft/advancements/CriterionTrigger;
-accessible method net/minecraft/world/inventory/MenuType <init> (Lnet/minecraft/world/inventory/MenuType$MenuSupplier;)V
-accessible class net/minecraft/world/inventory/MenuType$MenuSupplier
+transitive-accessible method net/minecraft/world/inventory/MenuType <init> (Lnet/minecraft/world/inventory/MenuType$MenuSupplier;)V
+transitive-accessible class net/minecraft/world/inventory/MenuType$MenuSupplier
 accessible method net/minecraft/world/entity/Entity getEncodeId ()Ljava/lang/String;
 accessible field net/minecraft/server/packs/repository/PackRepository sources Ljava/util/Set;
 mutable field net/minecraft/server/packs/repository/PackRepository sources Ljava/util/Set;


### PR DESCRIPTION
Both impls just do the same thing anyway (`new MenuType<>(factory::create)`) so why not make this transitive?