### PR TITLE
Add simple interface injection extensions

### DIFF
--- a/common/src/main/java/dev/architectury/core/fluid/SimpleArchitecturyFluidAttributes.java
+++ b/common/src/main/java/dev/architectury/core/fluid/SimpleArchitecturyFluidAttributes.java
@@ -64,7 +64,7 @@ public class SimpleArchitecturyFluidAttributes implements ArchitecturyFluidAttri
     private SoundEvent fillSound = SoundEvents.BUCKET_FILL;
     @Nullable
     private SoundEvent emptySound = SoundEvents.BUCKET_EMPTY;
-    private final Supplier<String> defaultTranslationKey = Suppliers.memoize(() -> Util.makeDescriptionId("fluid", getSourceFluid().arch$holder()));
+    private final Supplier<String> defaultTranslationKey = Suppliers.memoize(() -> Util.makeDescriptionId("fluid", getSourceFluid().arch$registryName()));
     
     public static SimpleArchitecturyFluidAttributes ofSupplier(Supplier<? extends Supplier<? extends Fluid>> flowingFluid, Supplier<? extends Supplier<? extends Fluid>> sourceFluid) {
         return of(() -> flowingFluid.get().get(), () -> sourceFluid.get().get());

--- a/common/src/main/java/dev/architectury/core/fluid/SimpleArchitecturyFluidAttributes.java
+++ b/common/src/main/java/dev/architectury/core/fluid/SimpleArchitecturyFluidAttributes.java
@@ -21,11 +21,9 @@ package dev.architectury.core.fluid;
 
 import com.google.common.base.Suppliers;
 import dev.architectury.fluid.FluidStack;
-import dev.architectury.registry.registries.Registries;
 import dev.architectury.registry.registries.RegistrySupplier;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
@@ -66,7 +64,7 @@ public class SimpleArchitecturyFluidAttributes implements ArchitecturyFluidAttri
     private SoundEvent fillSound = SoundEvents.BUCKET_FILL;
     @Nullable
     private SoundEvent emptySound = SoundEvents.BUCKET_EMPTY;
-    private final Supplier<String> defaultTranslationKey = Suppliers.memoize(() -> Util.makeDescriptionId("fluid", Registries.getId(getSourceFluid(), Registry.FLUID_REGISTRY)));
+    private final Supplier<String> defaultTranslationKey = Suppliers.memoize(() -> Util.makeDescriptionId("fluid", getSourceFluid().arch$getRegistryName()));
     
     public static SimpleArchitecturyFluidAttributes ofSupplier(Supplier<? extends Supplier<? extends Fluid>> flowingFluid, Supplier<? extends Supplier<? extends Fluid>> sourceFluid) {
         return of(() -> flowingFluid.get().get(), () -> sourceFluid.get().get());

--- a/common/src/main/java/dev/architectury/core/fluid/SimpleArchitecturyFluidAttributes.java
+++ b/common/src/main/java/dev/architectury/core/fluid/SimpleArchitecturyFluidAttributes.java
@@ -64,7 +64,7 @@ public class SimpleArchitecturyFluidAttributes implements ArchitecturyFluidAttri
     private SoundEvent fillSound = SoundEvents.BUCKET_FILL;
     @Nullable
     private SoundEvent emptySound = SoundEvents.BUCKET_EMPTY;
-    private final Supplier<String> defaultTranslationKey = Suppliers.memoize(() -> Util.makeDescriptionId("fluid", getSourceFluid().arch$getRegistryName()));
+    private final Supplier<String> defaultTranslationKey = Suppliers.memoize(() -> Util.makeDescriptionId("fluid", getSourceFluid().arch$holder()));
     
     public static SimpleArchitecturyFluidAttributes ofSupplier(Supplier<? extends Supplier<? extends Fluid>> flowingFluid, Supplier<? extends Supplier<? extends Fluid>> sourceFluid) {
         return of(() -> flowingFluid.get().get(), () -> sourceFluid.get().get());

--- a/common/src/main/java/dev/architectury/core/item/ArchitecturySpawnEggItem.java
+++ b/common/src/main/java/dev/architectury/core/item/ArchitecturySpawnEggItem.java
@@ -74,8 +74,8 @@ public class ArchitecturySpawnEggItem extends SpawnEggItem {
         this.entityType = Objects.requireNonNull(entityType, "entityType");
         SpawnEggItem.BY_ID.remove(null);
         entityType.listen(type -> {
-            LOGGER.debug("Registering spawn egg {} for {}", Objects.toString(this.arch$holder()),
-                    Objects.toString(type.arch$holder()));
+            LOGGER.debug("Registering spawn egg {} for {}", Objects.toString(this.arch$registryName()),
+                    Objects.toString(type.arch$registryName()));
             SpawnEggItem.BY_ID.put(type, this);
             this.defaultType = type;
             

--- a/common/src/main/java/dev/architectury/core/item/ArchitecturySpawnEggItem.java
+++ b/common/src/main/java/dev/architectury/core/item/ArchitecturySpawnEggItem.java
@@ -19,11 +19,9 @@
 
 package dev.architectury.core.item;
 
-import dev.architectury.registry.registries.Registries;
 import dev.architectury.registry.registries.RegistrySupplier;
 import net.minecraft.core.BlockSource;
 import net.minecraft.core.Direction;
-import net.minecraft.core.Registry;
 import net.minecraft.core.dispenser.DefaultDispenseItemBehavior;
 import net.minecraft.core.dispenser.DispenseItemBehavior;
 import net.minecraft.nbt.CompoundTag;
@@ -76,8 +74,8 @@ public class ArchitecturySpawnEggItem extends SpawnEggItem {
         this.entityType = Objects.requireNonNull(entityType, "entityType");
         SpawnEggItem.BY_ID.remove(null);
         entityType.listen(type -> {
-            LOGGER.debug("Registering spawn egg {} for {}", Objects.toString(Registries.getId(this, Registry.ITEM_REGISTRY)),
-                    Objects.toString(Registries.getId(type, Registry.ENTITY_TYPE_REGISTRY)));
+            LOGGER.debug("Registering spawn egg {} for {}", Objects.toString(this.arch$getRegistryName()),
+                    Objects.toString(type.arch$getRegistryName()));
             SpawnEggItem.BY_ID.put(type, this);
             this.defaultType = type;
             

--- a/common/src/main/java/dev/architectury/core/item/ArchitecturySpawnEggItem.java
+++ b/common/src/main/java/dev/architectury/core/item/ArchitecturySpawnEggItem.java
@@ -74,8 +74,8 @@ public class ArchitecturySpawnEggItem extends SpawnEggItem {
         this.entityType = Objects.requireNonNull(entityType, "entityType");
         SpawnEggItem.BY_ID.remove(null);
         entityType.listen(type -> {
-            LOGGER.debug("Registering spawn egg {} for {}", Objects.toString(this.arch$getRegistryName()),
-                    Objects.toString(type.arch$getRegistryName()));
+            LOGGER.debug("Registering spawn egg {} for {}", Objects.toString(this.arch$holder()),
+                    Objects.toString(type.arch$holder()));
             SpawnEggItem.BY_ID.put(type, this);
             this.defaultType = type;
             

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedBlockEntityTypeExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedBlockEntityTypeExtension.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.extensions.injected;
+
+import dev.architectury.registry.registries.Registries;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+public interface InjectedBlockEntityTypeExtension extends InjectedRegistryEntryExtension {
+    @Override
+    default ResourceLocation arch$getRegistryName() {
+        return Registries.getId((BlockEntityType<?>) this, Registry.BLOCK_ENTITY_TYPE_REGISTRY);
+    }
+}

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedBlockExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedBlockExtension.java
@@ -20,13 +20,13 @@
 package dev.architectury.extensions.injected;
 
 import dev.architectury.registry.registries.Registries;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 
-public interface InjectedBlockExtension extends InjectedRegistryEntryExtension {
+public interface InjectedBlockExtension extends InjectedRegistryEntryExtension<Block> {
     @Override
-    default ResourceLocation arch$getRegistryName() {
-        return Registries.getId((Block) this, Registry.BLOCK_REGISTRY);
+    default Holder<Block> arch$holder() {
+        return ((Block) this).builtInRegistryHolder();
     }
 }

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedBlockExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedBlockExtension.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.extensions.injected;
+
+import dev.architectury.registry.registries.Registries;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Block;
+
+public interface InjectedBlockExtension extends InjectedRegistryEntryExtension {
+    @Override
+    default ResourceLocation arch$getRegistryName() {
+        return Registries.getId((Block) this, Registry.BLOCK_REGISTRY);
+    }
+}

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedBucketItemExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedBucketItemExtension.java
@@ -1,0 +1,11 @@
+package dev.architectury.extensions.injected;
+
+import dev.architectury.hooks.fluid.FluidBucketHooks;
+import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.level.material.Fluid;
+
+public interface InjectedBucketItemExtension {
+    default Fluid arch$getFluid() {
+        return FluidBucketHooks.getFluid((BucketItem) this);
+    }
+}

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedEntityTypeExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedEntityTypeExtension.java
@@ -20,13 +20,13 @@
 package dev.architectury.extensions.injected;
 
 import dev.architectury.registry.registries.Registries;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 
-public interface InjectedEntityTypeExtension extends InjectedRegistryEntryExtension {
+public interface InjectedEntityTypeExtension extends InjectedRegistryEntryExtension<EntityType<?>> {
     @Override
-    default ResourceLocation arch$getRegistryName() {
-        return Registries.getId((EntityType<?>) this, Registry.ENTITY_TYPE_REGISTRY);
+    default Holder<EntityType<?>> arch$holder() {
+        return ((EntityType<?>) this).builtInRegistryHolder();
     }
 }

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedEntityTypeExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedEntityTypeExtension.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.extensions.injected;
+
+import dev.architectury.registry.registries.Registries;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EntityType;
+
+public interface InjectedEntityTypeExtension extends InjectedRegistryEntryExtension {
+    @Override
+    default ResourceLocation arch$getRegistryName() {
+        return Registries.getId((EntityType<?>) this, Registry.ENTITY_TYPE_REGISTRY);
+    }
+}

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedFluidExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedFluidExtension.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.extensions.injected;
+
+import dev.architectury.registry.registries.Registries;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.material.Fluid;
+
+public interface InjectedFluidExtension extends InjectedRegistryEntryExtension {
+    @Override
+    default ResourceLocation arch$getRegistryName() {
+        return Registries.getId((Fluid) this, Registry.FLUID_REGISTRY);
+    }
+}

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedFluidExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedFluidExtension.java
@@ -20,13 +20,13 @@
 package dev.architectury.extensions.injected;
 
 import dev.architectury.registry.registries.Registries;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.material.Fluid;
 
-public interface InjectedFluidExtension extends InjectedRegistryEntryExtension {
+public interface InjectedFluidExtension extends InjectedRegistryEntryExtension<Fluid> {
     @Override
-    default ResourceLocation arch$getRegistryName() {
-        return Registries.getId((Fluid) this, Registry.FLUID_REGISTRY);
+    default Holder<Fluid> arch$holder() {
+        return ((Fluid) this).builtInRegistryHolder();
     }
 }

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedFoodPropertiesBuilderExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedFoodPropertiesBuilderExtension.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.extensions.injected;
+
+import dev.architectury.hooks.item.food.FoodPropertiesHooks;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.food.FoodProperties;
+
+import java.util.function.Supplier;
+
+public interface InjectedFoodPropertiesBuilderExtension {
+    default FoodProperties.Builder arch$effect(Supplier<? extends MobEffectInstance> effectSupplier, float chance) {
+        FoodPropertiesHooks.effect((FoodProperties.Builder) this, effectSupplier, chance);
+        return (FoodProperties.Builder) this;
+    }
+}

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedGameEventExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedGameEventExtension.java
@@ -19,14 +19,12 @@
 
 package dev.architectury.extensions.injected;
 
-import dev.architectury.registry.registries.Registries;
-import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.gameevent.GameEvent;
 
-public interface InjectedBlockEntityTypeExtension extends InjectedRegistryEntryExtension {
+public interface InjectedGameEventExtension extends InjectedRegistryEntryExtension<GameEvent> {
     @Override
-    default ResourceLocation arch$getRegistryName() {
-        return Registries.getId((BlockEntityType<?>) this, Registry.BLOCK_ENTITY_TYPE_REGISTRY);
+    default Holder<GameEvent> arch$holder() {
+        return ((GameEvent) this).builtInRegistryHolder();
     }
 }

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedItemExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedItemExtension.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.extensions.injected;
+
+import dev.architectury.registry.registries.Registries;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+
+public interface InjectedItemExtension extends InjectedRegistryEntryExtension {
+    @Override
+    default ResourceLocation arch$getRegistryName() {
+        return Registries.getId((Item) this, Registry.ITEM_REGISTRY);
+    }
+}

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedItemExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedItemExtension.java
@@ -20,13 +20,13 @@
 package dev.architectury.extensions.injected;
 
 import dev.architectury.registry.registries.Registries;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 
-public interface InjectedItemExtension extends InjectedRegistryEntryExtension {
+public interface InjectedItemExtension extends InjectedRegistryEntryExtension<Item> {
     @Override
-    default ResourceLocation arch$getRegistryName() {
-        return Registries.getId((Item) this, Registry.ITEM_REGISTRY);
+    default Holder<Item> arch$holder() {
+        return ((Item) this).builtInRegistryHolder();
     }
 }

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedRegistryEntryExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedRegistryEntryExtension.java
@@ -20,7 +20,15 @@
 package dev.architectury.extensions.injected;
 
 import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
 
 public interface InjectedRegistryEntryExtension<T> {
     Holder<T> arch$holder();
+    
+    @Nullable
+    default ResourceLocation arch$registryName() {
+        return arch$holder().unwrapKey().map(ResourceKey::location).orElse(null);
+    }
 }

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedRegistryEntryExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedRegistryEntryExtension.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.extensions.injected;
+
+import net.minecraft.resources.ResourceLocation;
+
+public interface InjectedRegistryEntryExtension {
+    ResourceLocation arch$getRegistryName();
+}

--- a/common/src/main/java/dev/architectury/extensions/injected/InjectedRegistryEntryExtension.java
+++ b/common/src/main/java/dev/architectury/extensions/injected/InjectedRegistryEntryExtension.java
@@ -19,8 +19,8 @@
 
 package dev.architectury.extensions.injected;
 
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.core.Holder;
 
-public interface InjectedRegistryEntryExtension {
-    ResourceLocation arch$getRegistryName();
+public interface InjectedRegistryEntryExtension<T> {
+    Holder<T> arch$holder();
 }

--- a/common/src/main/java/dev/architectury/mixin/inject/MixinBlock.java
+++ b/common/src/main/java/dev/architectury/mixin/inject/MixinBlock.java
@@ -1,0 +1,9 @@
+package dev.architectury.mixin.inject;
+
+import dev.architectury.extensions.injected.InjectedBlockExtension;
+import net.minecraft.world.level.block.Block;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(Block.class)
+public class MixinBlock implements InjectedBlockExtension {
+}

--- a/common/src/main/java/dev/architectury/mixin/inject/MixinBlockEntityType.java
+++ b/common/src/main/java/dev/architectury/mixin/inject/MixinBlockEntityType.java
@@ -1,0 +1,9 @@
+package dev.architectury.mixin.inject;
+
+import dev.architectury.extensions.injected.InjectedBlockEntityTypeExtension;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(BlockEntityType.class)
+public class MixinBlockEntityType implements InjectedBlockEntityTypeExtension {
+}

--- a/common/src/main/java/dev/architectury/mixin/inject/MixinBlockEntityType.java
+++ b/common/src/main/java/dev/architectury/mixin/inject/MixinBlockEntityType.java
@@ -1,9 +1,9 @@
 package dev.architectury.mixin.inject;
 
-import dev.architectury.extensions.injected.InjectedBlockEntityTypeExtension;
+import dev.architectury.extensions.injected.InjectedGameEventExtension;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import org.spongepowered.asm.mixin.Mixin;
 
 @Mixin(BlockEntityType.class)
-public class MixinBlockEntityType implements InjectedBlockEntityTypeExtension {
+public class MixinBlockEntityType implements InjectedGameEventExtension {
 }

--- a/common/src/main/java/dev/architectury/mixin/inject/MixinBucketItem.java
+++ b/common/src/main/java/dev/architectury/mixin/inject/MixinBucketItem.java
@@ -1,0 +1,9 @@
+package dev.architectury.mixin.inject;
+
+import dev.architectury.extensions.injected.InjectedBucketItemExtension;
+import net.minecraft.world.item.BucketItem;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(BucketItem.class)
+public class MixinBucketItem implements InjectedBucketItemExtension {
+}

--- a/common/src/main/java/dev/architectury/mixin/inject/MixinEntityType.java
+++ b/common/src/main/java/dev/architectury/mixin/inject/MixinEntityType.java
@@ -1,0 +1,9 @@
+package dev.architectury.mixin.inject;
+
+import dev.architectury.extensions.injected.InjectedEntityTypeExtension;
+import net.minecraft.world.entity.EntityType;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(EntityType.class)
+public class MixinEntityType implements InjectedEntityTypeExtension {
+}

--- a/common/src/main/java/dev/architectury/mixin/inject/MixinFluid.java
+++ b/common/src/main/java/dev/architectury/mixin/inject/MixinFluid.java
@@ -1,0 +1,9 @@
+package dev.architectury.mixin.inject;
+
+import dev.architectury.extensions.injected.InjectedFluidExtension;
+import net.minecraft.world.level.material.Fluid;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(Fluid.class)
+public class MixinFluid implements InjectedFluidExtension {
+}

--- a/common/src/main/java/dev/architectury/mixin/inject/MixinItem.java
+++ b/common/src/main/java/dev/architectury/mixin/inject/MixinItem.java
@@ -1,0 +1,9 @@
+package dev.architectury.mixin.inject;
+
+import dev.architectury.extensions.injected.InjectedItemExtension;
+import net.minecraft.world.item.Item;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(Item.class)
+public class MixinItem implements InjectedItemExtension {
+}

--- a/common/src/main/resources/architectury-common.mixins.json
+++ b/common/src/main/resources/architectury-common.mixins.json
@@ -6,6 +6,12 @@
   "client": [
   ],
   "mixins": [
+    "inject.MixinBlock",
+    "inject.MixinBlockEntityType",
+    "inject.MixinBucketItem",
+    "inject.MixinEntityType",
+    "inject.MixinFluid",
+    "inject.MixinItem",
     "MixinLightningBolt"
   ],
   "injectors": {

--- a/common/src/main/resources/architectury.common.json
+++ b/common/src/main/resources/architectury.common.json
@@ -1,3 +1,26 @@
 {
-  "accessWidener": "architectury.accessWidener"
+  "accessWidener": "architectury.accessWidener",
+  "injected_interfaces": {
+    "net/minecraft/class_1792": [
+      "dev/architectury/extensions/injected/InjectedItemExtension"
+    ],
+    "net/minecraft/class_2248": [
+      "dev/architectury/extensions/injected/InjectedBlockExtension"
+    ],
+    "net/minecraft/class_3611": [
+      "dev/architectury/extensions/injected/InjectedFluidExtension"
+    ],
+    "net/minecraft/class_1299": [
+      "dev/architectury/extensions/injected/InjectedEntityTypeExtension"
+    ],
+    "net/minecraft/class_2591": [
+      "dev/architectury/extensions/injected/InjectedBlockEntityTypeExtension"
+    ],
+    "net/minecraft/class_1755": [
+      "dev/architectury/extensions/injected/InjectedBucketItemExtension"
+    ],
+    "net/minecraft/class_4174$class_4175": [
+      "dev/architectury/extensions/injected/InjectedFoodPropertiesBuilderExtension"
+    ]
+  }
 }

--- a/fabric/src/main/java/dev/architectury/hooks/item/tool/fabric/HoeItemHooksImpl.java
+++ b/fabric/src/main/java/dev/architectury/hooks/item/tool/fabric/HoeItemHooksImpl.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package dev.architectury.hooks.item.tool.fabric;
 
 import com.google.common.collect.ImmutableMap;

--- a/forge/src/main/java/dev/architectury/hooks/item/tool/forge/HoeItemHooksImpl.java
+++ b/forge/src/main/java/dev/architectury/hooks/item/tool/forge/HoeItemHooksImpl.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package dev.architectury.hooks.item.tool.forge;
 
 import net.minecraft.world.item.context.UseOnContext;


### PR DESCRIPTION
This PR adds `arch$holder()` to many frequent classes: `Item`, `Block`, `GameEvent`, `Fluid`, and `EntityType`.

This also adds `arch$effect` for Food.Properties builder and `arch$getFluid` into `BucketItem`.

The scope of the PR can be extended in the future, but I think this is enough for now.

We are not an API used by literally every mod yet, which is why the methods are prefixed with `arch$` to avoid conflicts.