### PR TITLE
Further platform extensions

### DIFF
--- a/common/src/main/java/dev/architectury/platform/Mod.java
+++ b/common/src/main/java/dev/architectury/platform/Mod.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface Mod {
@@ -45,6 +46,16 @@ public interface Mod {
      */
     Optional<String> getLogoFile(int preferredSize);
     
+    /**
+     * Gets a list of all possible root paths for the mod.
+     * This is especially relevant on Fabric, as a single mod may have multiple source sets
+     * (such as client / server-specific ones), each corresponding to one root path.
+     *
+     * @return A list of root paths belonging to the mod
+     */
+    List<Path> getFilePaths();
+    
+    @Deprecated
     Path getFilePath();
     
     Collection<String> getAuthors();

--- a/common/src/main/java/dev/architectury/platform/Mod.java
+++ b/common/src/main/java/dev/architectury/platform/Mod.java
@@ -55,7 +55,10 @@ public interface Mod {
      */
     List<Path> getFilePaths();
     
-    @Deprecated
+    /**
+     * @deprecated Use {@link #getFilePaths()} instead
+     */
+    @Deprecated(forRemoval = true)
     Path getFilePath();
     
     Collection<String> getAuthors();

--- a/common/src/main/java/dev/architectury/platform/Platform.java
+++ b/common/src/main/java/dev/architectury/platform/Platform.java
@@ -51,10 +51,14 @@ public final class Platform {
             return;
         }
         
-        switch (ArchitecturyTarget.getCurrentTarget()) {
+        switch (getLoader()) {
             case "fabric" -> simpleLoaderCache = 0;
             case "forge" -> simpleLoaderCache = 1;
         }
+    }
+    
+    public static String getLoader() {
+        return ArchitecturyTarget.getCurrentTarget();
     }
     
     public static String getMinecraftVersion() {

--- a/common/src/main/java/dev/architectury/platform/Platform.java
+++ b/common/src/main/java/dev/architectury/platform/Platform.java
@@ -51,14 +51,10 @@ public final class Platform {
             return;
         }
         
-        switch (getLoader()) {
+        switch (ArchitecturyTarget.getCurrentTarget()) {
             case "fabric" -> simpleLoaderCache = 0;
             case "forge" -> simpleLoaderCache = 1;
         }
-    }
-    
-    public static String getLoader() {
-        return ArchitecturyTarget.getCurrentTarget();
     }
     
     public static String getMinecraftVersion() {

--- a/fabric/src/main/java/dev/architectury/platform/fabric/PlatformImpl.java
+++ b/fabric/src/main/java/dev/architectury/platform/fabric/PlatformImpl.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -121,7 +122,12 @@ public class PlatformImpl {
         public Optional<String> getLogoFile(int preferredSize) {
             return metadata.getIconPath(preferredSize);
         }
-        
+    
+        @Override
+        public List<Path> getFilePaths() {
+            return container.getRootPaths();
+        }
+    
         @Override
         public Path getFilePath() {
             return container.getRootPath();

--- a/forge/src/main/java/dev/architectury/platform/forge/PlatformImpl.java
+++ b/forge/src/main/java/dev/architectury/platform/forge/PlatformImpl.java
@@ -126,7 +126,12 @@ public class PlatformImpl {
         public Optional<String> getLogoFile(int i) {
             return this.info.getLogoFile();
         }
-        
+    
+        @Override
+        public List<Path> getFilePaths() {
+            return List.of(getFilePath());
+        }
+    
         @Override
         public Path getFilePath() {
             return this.info.getOwningFile().getFile().getFilePath();


### PR DESCRIPTION
This adds two methods to Platform, `Platform.getLoader()` which is a simple wrapper around `ArchitecturyTarget` for mods not using the plugin, and `Platform.getFilePaths()`, which can be used to get *all* root file paths of a mod that is split into multiple source sets, for instance.

Signed-off-by: Max <maxh2709@gmail.com>