### PR TITLE
Fix Platform#getFilePath not returning the *root* file path on Forge

### DIFF
--- a/common/src/main/java/dev/architectury/platform/Mod.java
+++ b/common/src/main/java/dev/architectury/platform/Mod.java
@@ -61,6 +61,15 @@ public interface Mod {
     @Deprecated(forRemoval = true)
     Path getFilePath();
     
+    /**
+     * Gets an NIO Path to the given resource contained within the mod file / folder.
+     * The path is verified to exist, and an empty optional is returned if it doesn't.
+     *
+     * @param path The resource to search for
+     * @return The path of the resource if it exists, or {@link Optional#empty()} if it doesn't
+     */
+    Optional<Path> findResource(String... path);
+    
     Collection<String> getAuthors();
     
     @Nullable

--- a/fabric/src/main/java/dev/architectury/platform/fabric/PlatformImpl.java
+++ b/fabric/src/main/java/dev/architectury/platform/fabric/PlatformImpl.java
@@ -132,7 +132,12 @@ public class PlatformImpl {
         public Path getFilePath() {
             return container.getRootPath();
         }
-        
+    
+        @Override
+        public Optional<Path> findResource(String... path) {
+            return container.findPath(String.join("/", path));
+        }
+    
         @Override
         public Collection<String> getAuthors() {
             return metadata.getAuthors().stream()

--- a/forge/src/main/java/dev/architectury/platform/forge/PlatformImpl.java
+++ b/forge/src/main/java/dev/architectury/platform/forge/PlatformImpl.java
@@ -134,7 +134,7 @@ public class PlatformImpl {
     
         @Override
         public Path getFilePath() {
-            return this.info.getOwningFile().getFile().getFilePath();
+            return this.info.getOwningFile().getFile().getSecureJar().getRootPath();
         }
         
         @Override

--- a/forge/src/main/java/dev/architectury/platform/forge/PlatformImpl.java
+++ b/forge/src/main/java/dev/architectury/platform/forge/PlatformImpl.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -126,15 +127,20 @@ public class PlatformImpl {
         public Optional<String> getLogoFile(int i) {
             return this.info.getLogoFile();
         }
-    
+        
         @Override
         public List<Path> getFilePaths() {
             return List.of(getFilePath());
         }
-    
+        
         @Override
         public Path getFilePath() {
             return this.info.getOwningFile().getFile().getSecureJar().getRootPath();
+        }
+        
+        @Override
+        public Optional<Path> findResource(String... path) {
+            return Optional.of(this.info.getOwningFile().getFile().findResource(path)).filter(Files::exists);
         }
         
         @Override


### PR DESCRIPTION
On Forge, the "primary" path, that is, the last path united by UnionFS, may be separate from the **root** path of the (union) filesystem. In addition to possibly being... quite a headache for certain use cases like finding resources (which may need its own hook, let me know if it should be added to this PR as well), this also breaks the assumption made by `getFilePaths()` and its deprecated cousin, `getFilePath()`, as those are explicitly meant to return the **root** path of the mod file system

Signed-off-by: Max <maxh2709@gmail.com>