### PR TITLE
Implement Forge's new Fluid API

### DIFF
--- a/common/src/main/java/dev/architectury/core/fluid/ArchitecturyFluidAttributes.java
+++ b/common/src/main/java/dev/architectury/core/fluid/ArchitecturyFluidAttributes.java
@@ -343,6 +343,7 @@ public interface ArchitecturyFluidAttributes {
      * @deprecated Please use and override {@link #getColor(FluidState, BlockAndTintGetter, BlockPos)}
      * or {@link #getColor(FluidStack)} instead, this method will be removed in a future version.
      */
+    @Deprecated(forRemoval = true)
     int getColor(@Nullable FluidStack stack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos);
     
     /**

--- a/common/src/main/java/dev/architectury/core/fluid/ArchitecturyFluidAttributes.java
+++ b/common/src/main/java/dev/architectury/core/fluid/ArchitecturyFluidAttributes.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -205,6 +206,20 @@ public interface ArchitecturyFluidAttributes {
      * <p>
      * The vanilla water location is {@code "block/water_still"}.
      *
+     * @param state the fluid state, can be {@code null}
+     * @param level the level, can be {@code null}
+     * @param pos   the position, can be {@code null}
+     * @return the texture location
+     */
+    default ResourceLocation getSourceTexture(@Nullable FluidState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
+        return getSourceTexture(state == null ? null : FluidStack.create(state.getType(), FluidStack.bucketAmount()), level, pos);
+    }
+    
+    /**
+     * Returns the texture location of this fluid in its source form.
+     * <p>
+     * The vanilla water location is {@code "block/water_still"}.
+     *
      * @param stack the fluid stack, can be {@code null}
      * @return the texture location
      */
@@ -234,6 +249,20 @@ public interface ArchitecturyFluidAttributes {
      * @return the texture location
      */
     ResourceLocation getFlowingTexture(@Nullable FluidStack stack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos);
+    
+    /**
+     * Returns the texture location of this fluid in its flowing form.
+     * <p>
+     * The vanilla water location is {@code "block/water_flow"}.
+     *
+     * @param state the fluid state, can be {@code null}
+     * @param level the level, can be {@code null}
+     * @param pos   the position, can be {@code null}
+     * @return the texture location
+     */
+    default ResourceLocation getFlowingTexture(@Nullable FluidState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
+        return getFlowingTexture(state == null ? null : FluidStack.create(state.getType(), FluidStack.bucketAmount()), level, pos);
+    }
     
     /**
      * Returns the texture location of this fluid in its flowing form.
@@ -278,6 +307,21 @@ public interface ArchitecturyFluidAttributes {
      * <p>
      * The vanilla water location is {@code "block/water_overlay"}.
      *
+     * @param state the fluid state, can be {@code null}
+     * @param level the level, can be {@code null}
+     * @param pos   the position, can be {@code null}
+     * @return the texture location, can be {@code null}
+     */
+    @Nullable
+    default ResourceLocation getOverlayTexture(@Nullable FluidState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
+        return getOverlayTexture(state == null ? null : FluidStack.create(state.getType(), FluidStack.bucketAmount()), level, pos);
+    }
+    
+    /**
+     * Returns the overlay texture location of this fluid behind transparent blocks.
+     * <p>
+     * The vanilla water location is {@code "block/water_overlay"}.
+     *
      * @param stack the fluid stack, can be {@code null}
      * @return the texture location, can be {@code null}
      */
@@ -307,6 +351,18 @@ public interface ArchitecturyFluidAttributes {
      * @return the color
      */
     int getColor(@Nullable FluidStack stack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos);
+    
+    /**
+     * Returns the color of the fluid.
+     *
+     * @param state the fluid state, can be {@code null}
+     * @param level the level, can be {@code null}
+     * @param pos   the position, can be {@code null}
+     * @return the color
+     */
+    default int getColor(@Nullable FluidState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
+        return getColor(state == null ? null : FluidStack.create(state.getType(), FluidStack.bucketAmount()), level, pos);
+    }
     
     /**
      * Returns the color of the fluid.

--- a/common/src/main/java/dev/architectury/core/fluid/ArchitecturyFluidAttributes.java
+++ b/common/src/main/java/dev/architectury/core/fluid/ArchitecturyFluidAttributes.java
@@ -259,6 +259,46 @@ public interface ArchitecturyFluidAttributes {
     }
     
     /**
+     * Returns the overlay texture location of this fluid behind transparent blocks.
+     * <p>
+     * The vanilla water location is {@code "block/water_overlay"}.
+     *
+     * @param stack the fluid stack, can be {@code null}
+     * @param level the level, can be {@code null}
+     * @param pos   the position, can be {@code null}
+     * @return the texture location, can be {@code null}
+     */
+    @Nullable
+    default ResourceLocation getOverlayTexture(@Nullable FluidStack stack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
+        return null;
+    }
+    
+    /**
+     * Returns the overlay texture location of this fluid behind transparent blocks.
+     * <p>
+     * The vanilla water location is {@code "block/water_overlay"}.
+     *
+     * @param stack the fluid stack, can be {@code null}
+     * @return the texture location, can be {@code null}
+     */
+    @Nullable
+    default ResourceLocation getOverlayTexture(@Nullable FluidStack stack) {
+        return getOverlayTexture(stack, null, null);
+    }
+    
+    /**
+     * Returns the overlay texture location of this fluid behind transparent blocks.
+     * <p>
+     * The vanilla water location is {@code "block/water_overlay"}.
+     *
+     * @return the texture location, can be {@code null}
+     */
+    @Nullable
+    default ResourceLocation getOverlayTexture() {
+        return getOverlayTexture(null);
+    }
+    
+    /**
      * Returns the color of the fluid.
      *
      * @param stack the fluid stack, can be {@code null}

--- a/common/src/main/java/dev/architectury/core/fluid/ArchitecturyFluidAttributes.java
+++ b/common/src/main/java/dev/architectury/core/fluid/ArchitecturyFluidAttributes.java
@@ -198,7 +198,10 @@ public interface ArchitecturyFluidAttributes {
      * @param level the level, can be {@code null}
      * @param pos   the position, can be {@code null}
      * @return the texture location
+     * @deprecated Please use and override {@link #getSourceTexture(FluidState, BlockAndTintGetter, BlockPos)}
+     * or {@link #getSourceTexture(FluidStack)} instead, this method will be removed in a future version.
      */
+    @Deprecated(forRemoval = true)
     ResourceLocation getSourceTexture(@Nullable FluidStack stack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos);
     
     /**
@@ -247,7 +250,10 @@ public interface ArchitecturyFluidAttributes {
      * @param level the level, can be {@code null}
      * @param pos   the position, can be {@code null}
      * @return the texture location
+     * @deprecated Please use and override {@link #getFlowingTexture(FluidState, BlockAndTintGetter, BlockPos)}
+     * or {@link #getFlowingTexture(FluidStack)} instead, this method will be removed in a future version.
      */
+    @Deprecated(forRemoval = true)
     ResourceLocation getFlowingTexture(@Nullable FluidStack stack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos);
     
     /**
@@ -292,21 +298,6 @@ public interface ArchitecturyFluidAttributes {
      * <p>
      * The vanilla water location is {@code "block/water_overlay"}.
      *
-     * @param stack the fluid stack, can be {@code null}
-     * @param level the level, can be {@code null}
-     * @param pos   the position, can be {@code null}
-     * @return the texture location, can be {@code null}
-     */
-    @Nullable
-    default ResourceLocation getOverlayTexture(@Nullable FluidStack stack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
-        return null;
-    }
-    
-    /**
-     * Returns the overlay texture location of this fluid behind transparent blocks.
-     * <p>
-     * The vanilla water location is {@code "block/water_overlay"}.
-     *
      * @param state the fluid state, can be {@code null}
      * @param level the level, can be {@code null}
      * @param pos   the position, can be {@code null}
@@ -314,7 +305,7 @@ public interface ArchitecturyFluidAttributes {
      */
     @Nullable
     default ResourceLocation getOverlayTexture(@Nullable FluidState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
-        return getOverlayTexture(state == null ? null : FluidStack.create(state.getType(), FluidStack.bucketAmount()), level, pos);
+        return null;
     }
     
     /**
@@ -327,7 +318,7 @@ public interface ArchitecturyFluidAttributes {
      */
     @Nullable
     default ResourceLocation getOverlayTexture(@Nullable FluidStack stack) {
-        return getOverlayTexture(stack, null, null);
+        return null;
     }
     
     /**
@@ -349,6 +340,8 @@ public interface ArchitecturyFluidAttributes {
      * @param level the level, can be {@code null}
      * @param pos   the position, can be {@code null}
      * @return the color
+     * @deprecated Please use and override {@link #getColor(FluidState, BlockAndTintGetter, BlockPos)}
+     * or {@link #getColor(FluidStack)} instead, this method will be removed in a future version.
      */
     int getColor(@Nullable FluidStack stack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos);
     

--- a/common/src/main/java/dev/architectury/core/fluid/SimpleArchitecturyFluidAttributes.java
+++ b/common/src/main/java/dev/architectury/core/fluid/SimpleArchitecturyFluidAttributes.java
@@ -35,6 +35,7 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
@@ -55,6 +56,8 @@ public class SimpleArchitecturyFluidAttributes implements ArchitecturyFluidAttri
     private ResourceLocation sourceTexture;
     @Nullable
     private ResourceLocation flowingTexture;
+    @Nullable
+    private ResourceLocation overlayTexture;
     private int color = 0xffffff;
     private int luminosity = 0;
     private int density = 1000;
@@ -167,7 +170,7 @@ public class SimpleArchitecturyFluidAttributes implements ArchitecturyFluidAttri
     }
     
     /**
-     * @see ArchitecturyFluidAttributes#getSourceTexture(FluidStack, BlockAndTintGetter, BlockPos)
+     * @see ArchitecturyFluidAttributes#getSourceTexture(FluidState, BlockAndTintGetter, BlockPos)
      */
     public SimpleArchitecturyFluidAttributes sourceTexture(ResourceLocation sourceTexture) {
         this.sourceTexture = sourceTexture;
@@ -175,7 +178,7 @@ public class SimpleArchitecturyFluidAttributes implements ArchitecturyFluidAttri
     }
     
     /**
-     * @see ArchitecturyFluidAttributes#getFlowingTexture(FluidStack, BlockAndTintGetter, BlockPos)
+     * @see ArchitecturyFluidAttributes#getFlowingTexture(FluidState, BlockAndTintGetter, BlockPos)
      */
     public SimpleArchitecturyFluidAttributes flowingTexture(ResourceLocation flowingTexture) {
         this.flowingTexture = flowingTexture;
@@ -183,7 +186,15 @@ public class SimpleArchitecturyFluidAttributes implements ArchitecturyFluidAttri
     }
     
     /**
-     * @see ArchitecturyFluidAttributes#getColor(FluidStack, BlockAndTintGetter, BlockPos)
+     * @see ArchitecturyFluidAttributes#getFlowingTexture(FluidState, BlockAndTintGetter, BlockPos)
+     */
+    public SimpleArchitecturyFluidAttributes overlayTexture(ResourceLocation overlayTexture) {
+        this.overlayTexture = overlayTexture;
+        return this;
+    }
+    
+    /**
+     * @see ArchitecturyFluidAttributes#getColor(FluidState, BlockAndTintGetter, BlockPos)
      */
     public SimpleArchitecturyFluidAttributes color(int color) {
         this.color = color;
@@ -315,6 +326,11 @@ public class SimpleArchitecturyFluidAttributes implements ArchitecturyFluidAttri
     @Override
     public ResourceLocation getFlowingTexture(@Nullable FluidStack stack, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
         return flowingTexture;
+    }
+    
+    @Override
+    public ResourceLocation getOverlayTexture(@Nullable FluidState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos) {
+        return overlayTexture;
     }
     
     @Override

--- a/fabric/src/main/java/dev/architectury/core/fluid/fabric/ArchitecturyFluidRenderingFabric.java
+++ b/fabric/src/main/java/dev/architectury/core/fluid/fabric/ArchitecturyFluidRenderingFabric.java
@@ -42,8 +42,8 @@ import java.util.function.Function;
 @Environment(EnvType.CLIENT)
 class ArchitecturyFluidRenderingFabric implements FluidVariantRenderHandler, FluidRenderHandler {
     private final ArchitecturyFluidAttributes attributes;
-    private final TextureAtlasSprite[] sprites = new TextureAtlasSprite[2];
-    private final TextureAtlasSprite[] spritesOther = new TextureAtlasSprite[2];
+    private final TextureAtlasSprite[] sprites = new TextureAtlasSprite[3];
+    private final TextureAtlasSprite[] spritesOther = new TextureAtlasSprite[3];
     
     public ArchitecturyFluidRenderingFabric(ArchitecturyFluidAttributes attributes) {
         this.attributes = attributes;
@@ -56,6 +56,8 @@ class ArchitecturyFluidRenderingFabric implements FluidVariantRenderHandler, Flu
         Function<ResourceLocation, TextureAtlasSprite> atlas = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS);
         sprites[0] = atlas.apply(attributes.getSourceTexture(stack));
         sprites[1] = atlas.apply(attributes.getFlowingTexture(stack));
+        ResourceLocation overlayTexture = attributes.getOverlayTexture(stack);
+        sprites[2] = overlayTexture == null ? null : atlas.apply(overlayTexture);
         return sprites;
     }
     
@@ -70,6 +72,8 @@ class ArchitecturyFluidRenderingFabric implements FluidVariantRenderHandler, Flu
         Function<ResourceLocation, TextureAtlasSprite> atlas = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS);
         spritesOther[0] = atlas.apply(attributes.getSourceTexture(stack, view, pos));
         spritesOther[1] = atlas.apply(attributes.getFlowingTexture(stack, view, pos));
+        ResourceLocation overlayTexture = attributes.getOverlayTexture(stack, view, pos);
+        spritesOther[2] = overlayTexture == null ? null : atlas.apply(overlayTexture);
         return spritesOther;
     }
     

--- a/fabric/src/main/java/dev/architectury/core/fluid/fabric/ArchitecturyFluidRenderingFabric.java
+++ b/fabric/src/main/java/dev/architectury/core/fluid/fabric/ArchitecturyFluidRenderingFabric.java
@@ -68,17 +68,16 @@ class ArchitecturyFluidRenderingFabric implements FluidVariantRenderHandler, Flu
     
     @Override
     public TextureAtlasSprite[] getFluidSprites(@Nullable BlockAndTintGetter view, @Nullable BlockPos pos, FluidState state) {
-        FluidStack stack = FluidStack.create(state.getType(), FluidStack.bucketAmount());
         Function<ResourceLocation, TextureAtlasSprite> atlas = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS);
-        spritesOther[0] = atlas.apply(attributes.getSourceTexture(stack, view, pos));
-        spritesOther[1] = atlas.apply(attributes.getFlowingTexture(stack, view, pos));
-        ResourceLocation overlayTexture = attributes.getOverlayTexture(stack, view, pos);
+        spritesOther[0] = atlas.apply(attributes.getSourceTexture(state, view, pos));
+        spritesOther[1] = atlas.apply(attributes.getFlowingTexture(state, view, pos));
+        ResourceLocation overlayTexture = attributes.getOverlayTexture(state, view, pos);
         spritesOther[2] = overlayTexture == null ? null : atlas.apply(overlayTexture);
         return spritesOther;
     }
     
     @Override
     public int getFluidColor(@Nullable BlockAndTintGetter view, @Nullable BlockPos pos, FluidState state) {
-        return attributes.getColor(FluidStack.create(state.getType(), FluidStack.bucketAmount()), view, pos);
+        return attributes.getColor(state, view, pos);
     }
 }

--- a/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFlowingFluid.java
+++ b/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFlowingFluid.java
@@ -20,6 +20,8 @@
 package dev.architectury.core.fluid.forge.imitator;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import dev.architectury.core.fluid.ArchitecturyFluidAttributes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -37,7 +39,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
-import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import org.jetbrains.annotations.NotNull;
 
@@ -45,18 +47,20 @@ import java.util.Optional;
 
 public abstract class ArchitecturyFlowingFluid extends ForgeFlowingFluid {
     private final ArchitecturyFluidAttributes attributes;
+    private final Supplier<FluidType> forgeType;
     
     ArchitecturyFlowingFluid(ArchitecturyFluidAttributes attributes) {
         super(toForgeProperties(attributes));
         this.attributes = attributes;
+        this.forgeType = Suppliers.memoize(() -> {
+            return new ArchitecturyFluidAttributesForge(FluidType.Properties.create(), this, attributes);
+        });
     }
     
     private static Properties toForgeProperties(ArchitecturyFluidAttributes attributes) {
-        FluidAttributes.Builder forgeAttributes = new FluidAttributes.Builder(attributes.getSourceTexture(), attributes.getFlowingTexture(), (builder, fluid) ->
-                new ArchitecturyFluidAttributesForge(builder, fluid, attributes)) {
-        };
-        Properties forge = new Properties(attributes::getSourceFluid, attributes::getFlowingFluid, forgeAttributes);
-        if (attributes.canConvertToSource()) forge.canMultiply();
+        Properties forge = new Properties(Suppliers.memoize(() -> {
+            return new ArchitecturyFluidAttributesForge(FluidType.Properties.create(), attributes.getSourceFluid(), attributes);
+        }), attributes::getSourceFluid, attributes::getFlowingFluid);
         forge.slopeFindDistance(attributes.getSlopeFindDistance());
         forge.levelDecreasePerBlock(attributes.getDropOff());
         forge.bucket(() -> MoreObjects.firstNonNull(attributes.getBucketItem(), Items.AIR));
@@ -64,6 +68,11 @@ public abstract class ArchitecturyFlowingFluid extends ForgeFlowingFluid {
         forge.explosionResistance(attributes.getExplosionResistance());
         forge.block(() -> MoreObjects.firstNonNull(attributes.getBlock(), (LiquidBlock) Blocks.WATER));
         return forge;
+    }
+    
+    @Override
+    public FluidType getFluidType() {
+        return forgeType.get();
     }
     
     @Override

--- a/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFlowingFluid.java
+++ b/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFlowingFluid.java
@@ -37,11 +37,12 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
-import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public abstract class ArchitecturyFlowingFluid extends ForgeFlowingFluid {
     private final ArchitecturyFluidAttributes attributes;
@@ -52,11 +53,9 @@ public abstract class ArchitecturyFlowingFluid extends ForgeFlowingFluid {
     }
     
     private static Properties toForgeProperties(ArchitecturyFluidAttributes attributes) {
-        FluidAttributes.Builder forgeAttributes = new FluidAttributes.Builder(attributes.getSourceTexture(), attributes.getFlowingTexture(), (builder, fluid) ->
-                new ArchitecturyFluidAttributesForge(builder, fluid, attributes)) {
-        };
-        Properties forge = new Properties(attributes::getSourceFluid, attributes::getFlowingFluid, forgeAttributes);
-        if (attributes.canConvertToSource()) forge.canMultiply();
+        // TODO: Does this *want* the flowing fluid?
+        Supplier<FluidType> type = () -> new ArchitecturyFluidAttributesForge(FluidType.Properties.create(), attributes.getFlowingFluid(), attributes);
+        Properties forge = new Properties(type, attributes::getSourceFluid, attributes::getFlowingFluid);
         forge.slopeFindDistance(attributes.getSlopeFindDistance());
         forge.levelDecreasePerBlock(attributes.getDropOff());
         forge.bucket(() -> MoreObjects.firstNonNull(attributes.getBucketItem(), Items.AIR));

--- a/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFlowingFluid.java
+++ b/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFlowingFluid.java
@@ -20,7 +20,6 @@
 package dev.architectury.core.fluid.forge.imitator;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import dev.architectury.core.fluid.ArchitecturyFluidAttributes;
 import net.minecraft.core.BlockPos;

--- a/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFluidAttributesForge.java
+++ b/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFluidAttributesForge.java
@@ -100,23 +100,23 @@ class ArchitecturyFluidAttributesForge extends FluidType {
             
             @Override
             public ResourceLocation getStillTexture(FluidState state, BlockAndTintGetter getter, BlockPos pos) {
-                return attributes.getSourceTexture(convertSafe(state), getter, pos);
+                return attributes.getSourceTexture(state, getter, pos);
             }
             
             @Override
             public ResourceLocation getFlowingTexture(FluidState state, BlockAndTintGetter getter, BlockPos pos) {
-                return attributes.getFlowingTexture(convertSafe(state), getter, pos);
+                return attributes.getFlowingTexture(state, getter, pos);
             }
             
             @Override
             @Nullable
             public ResourceLocation getOverlayTexture(FluidState state, BlockAndTintGetter getter, BlockPos pos) {
-                return attributes.getOverlayTexture(convertSafe(state), getter, pos);
+                return attributes.getOverlayTexture(state, getter, pos);
             }
             
             @Override
             public int getColorTint(FluidState state, BlockAndTintGetter getter, BlockPos pos) {
-                return attributes.getColor(convertSafe(state), getter, pos);
+                return attributes.getColor(state, getter, pos);
             }
             
             @Override

--- a/forge/src/main/java/dev/architectury/hooks/fluid/forge/FluidStackHooksImpl.java
+++ b/forge/src/main/java/dev/architectury/hooks/fluid/forge/FluidStackHooksImpl.java
@@ -35,15 +35,16 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.RenderProperties;
 import org.jetbrains.annotations.Nullable;
 
 public class FluidStackHooksImpl {
     public static Component getName(FluidStack stack) {
-        return stack.getFluid().getAttributes().getDisplayName(FluidStackHooksForge.toForge(stack));
+        return stack.getFluid().getFluidType().getDescription(FluidStackHooksForge.toForge(stack));
     }
     
     public static String getTranslationKey(FluidStack stack) {
-        return stack.getFluid().getAttributes().getTranslationKey(FluidStackHooksForge.toForge(stack));
+        return stack.getFluid().getFluidType().getDescriptionId(FluidStackHooksForge.toForge(stack));
     }
     
     public static FluidStack read(FriendlyByteBuf buf) {
@@ -70,7 +71,7 @@ public class FluidStackHooksImpl {
     @Nullable
     public static TextureAtlasSprite getStillTexture(@Nullable BlockAndTintGetter level, @Nullable BlockPos pos, FluidState state) {
         if (state.getType() == Fluids.EMPTY) return null;
-        ResourceLocation texture = state.getType().getAttributes().getStillTexture(level, pos);
+        ResourceLocation texture = RenderProperties.get(state).getStillTexture(state, level, pos);
         return Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(texture);
     }
     
@@ -78,7 +79,7 @@ public class FluidStackHooksImpl {
     @Nullable
     public static TextureAtlasSprite getStillTexture(FluidStack stack) {
         if (stack.getFluid() == Fluids.EMPTY) return null;
-        ResourceLocation texture = stack.getFluid().getAttributes().getStillTexture(FluidStackHooksForge.toForge(stack));
+        ResourceLocation texture = RenderProperties.get(stack.getFluid()).getStillTexture(FluidStackHooksForge.toForge(stack));
         return Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(texture);
     }
     
@@ -86,7 +87,7 @@ public class FluidStackHooksImpl {
     @Nullable
     public static TextureAtlasSprite getStillTexture(Fluid fluid) {
         if (fluid == Fluids.EMPTY) return null;
-        ResourceLocation texture = fluid.getAttributes().getStillTexture();
+        ResourceLocation texture = RenderProperties.get(fluid).getStillTexture();
         return Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(texture);
     }
     
@@ -94,7 +95,7 @@ public class FluidStackHooksImpl {
     @Nullable
     public static TextureAtlasSprite getFlowingTexture(@Nullable BlockAndTintGetter level, @Nullable BlockPos pos, FluidState state) {
         if (state.getType() == Fluids.EMPTY) return null;
-        ResourceLocation texture = state.getType().getAttributes().getFlowingTexture(level, pos);
+        ResourceLocation texture = RenderProperties.get(state).getFlowingTexture(state, level, pos);
         return Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(texture);
     }
     
@@ -102,7 +103,7 @@ public class FluidStackHooksImpl {
     @Nullable
     public static TextureAtlasSprite getFlowingTexture(FluidStack stack) {
         if (stack.getFluid() == Fluids.EMPTY) return null;
-        ResourceLocation texture = stack.getFluid().getAttributes().getFlowingTexture(FluidStackHooksForge.toForge(stack));
+        ResourceLocation texture = RenderProperties.get(stack.getFluid()).getFlowingTexture(FluidStackHooksForge.toForge(stack));
         return Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(texture);
     }
     
@@ -110,61 +111,65 @@ public class FluidStackHooksImpl {
     @Nullable
     public static TextureAtlasSprite getFlowingTexture(Fluid fluid) {
         if (fluid == Fluids.EMPTY) return null;
-        ResourceLocation texture = fluid.getAttributes().getFlowingTexture();
+        ResourceLocation texture = RenderProperties.get(fluid).getFlowingTexture();
         return Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(texture);
     }
     
     @OnlyIn(Dist.CLIENT)
     public static int getColor(@Nullable BlockAndTintGetter level, @Nullable BlockPos pos, FluidState state) {
         if (state.getType() == Fluids.EMPTY) return -1;
-        return state.getType().getAttributes().getColor(level, pos);
+        return RenderProperties.get(state).getColorTint(state, level, pos);
     }
     
     @OnlyIn(Dist.CLIENT)
     public static int getColor(FluidStack stack) {
         if (stack.getFluid() == Fluids.EMPTY) return -1;
-        return stack.getFluid().getAttributes().getColor(FluidStackHooksForge.toForge(stack));
+        return RenderProperties.get(stack.getFluid()).getColorTint(FluidStackHooksForge.toForge(stack));
     }
     
     @OnlyIn(Dist.CLIENT)
     public static int getColor(Fluid fluid) {
         if (fluid == Fluids.EMPTY) return -1;
-        return fluid.getAttributes().getColor();
+        return RenderProperties.get(fluid).getColorTint();
     }
     
     public static int getLuminosity(FluidStack fluid, @Nullable Level level, @Nullable BlockPos pos) {
-        return fluid.getFluid().getAttributes().getLuminosity(FluidStackHooksForge.toForge(fluid));
+        return fluid.getFluid().getFluidType().getLightLevel(FluidStackHooksForge.toForge(fluid));
     }
     
+    @Deprecated(forRemoval = true)
     public static int getLuminosity(Fluid fluid, @Nullable Level level, @Nullable BlockPos pos) {
         if (level != null && pos != null) {
-            return fluid.getAttributes().getLuminosity(level, pos);
+            var state = level.getFluidState(pos);
+            return fluid.getFluidType().getLightLevel(state, level, pos);
         }
         
-        return fluid.getAttributes().getLuminosity();
+        return fluid.getFluidType().getLightLevel();
     }
     
     public static int getTemperature(FluidStack fluid, @Nullable Level level, @Nullable BlockPos pos) {
-        return fluid.getFluid().getAttributes().getTemperature(FluidStackHooksForge.toForge(fluid));
+        return fluid.getFluid().getFluidType().getTemperature(FluidStackHooksForge.toForge(fluid));
     }
     
     public static int getTemperature(Fluid fluid, @Nullable Level level, @Nullable BlockPos pos) {
         if (level != null && pos != null) {
-            return fluid.getAttributes().getTemperature(level, pos);
+            var state = level.getFluidState(pos);
+            return fluid.getFluidType().getTemperature(state, level, pos);
         }
         
-        return fluid.getAttributes().getTemperature();
+        return fluid.getFluidType().getTemperature();
     }
     
     public static int getViscosity(FluidStack fluid, @Nullable Level level, @Nullable BlockPos pos) {
-        return fluid.getFluid().getAttributes().getViscosity(FluidStackHooksForge.toForge(fluid));
+        return fluid.getFluid().getFluidType().getViscosity(FluidStackHooksForge.toForge(fluid));
     }
     
     public static int getViscosity(Fluid fluid, @Nullable Level level, @Nullable BlockPos pos) {
         if (level != null && pos != null) {
-            return fluid.getAttributes().getViscosity(level, pos);
+            var state = level.getFluidState(pos);
+            return fluid.getFluidType().getViscosity(state, level, pos);
         }
         
-        return fluid.getAttributes().getViscosity();
+        return fluid.getFluidType().getViscosity();
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ fabric_loader_version=0.14.6
 fabric_api_version=0.55.1+1.19
 mod_menu_version=3.1.0
 
-forge_version=41.0.17
+forge_version=41.0.30
 
 curseforge_id=419699
 modrinth_id=lhGA9TYQ


### PR DESCRIPTION
The new Forge Fluid API, introduced in build `41.0.28`, is a breaking change that directly affects Architectury as we used to rely on their FluidAttributes class for our own fluid attributes system. This PR updates, in as direct and non-breaking of a way as possible, that system to support Forge's new `FluidType` system instead.

TODOs:
- [ ] Test in userdev; this is unfortunately not possible for *me* to do because of a weird cyclic dependency error I seem to be the only one getting
- [ ] Add state-aware getters to FluidStackHooks and deprecate the getters using `Level` and `BlockPos` but not FluidState for removal
- [ ] The same should be applied to ArchitecturyFluidAttributes as well; maybe we should look into completely separating stack-aware and state-aware getters.
- [ ] General code cleanup
- [ ] At least look into adding support for certain new features in Forge's Fluid API if a Fabric-equivalent exists or is easy to create ourselves