### PR TITLE
Fix Item pickup not being cancellable on Forge

### DIFF
--- a/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
+++ b/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
@@ -296,7 +296,14 @@ public class EventHandlerImplCommon {
     
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void event(EntityItemPickupEvent event) {
-        PlayerEvent.PICKUP_ITEM_PRE.invoker().canPickup(event.getPlayer(), event.getItem(), event.getItem().getItem());
+        // note: this event is weird, cancel is equivalent to denying the pickup,
+        // and setting the result to ALLOW will pick it up without adding it to the player's inventory
+        var result = PlayerEvent.PICKUP_ITEM_PRE.invoker().canPickup(event.getPlayer(), event.getItem(), event.getItem().getItem());
+        if (result.isFalse()) {
+            event.setCanceled(true);
+        } else if (result.isTrue()) {
+            event.setResult(Event.Result.ALLOW);
+        }
     }
     
     @SubscribeEvent(priority = EventPriority.HIGH)


### PR DESCRIPTION
(see the title)

Side note: Forge's item pickup event is... a bit weird, as you will see in the implementation. Cancelling denies the pickup, while setting the result to ALLOW means the item pickup packet gets sent but the item never actually makes it to the player's inventory (as if they were in Creative Mode, basically)

Needs to be ported to 1.19 as well