### PR TITLE
Prevent running 1.19 Arch API on 1.19.1+

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
   },
   "icon": "icon.png",
   "depends": {
-    "minecraft": "~1.19-",
+    "minecraft": "=1.19",
     "fabricloader": ">=0.13.0",
     "fabric": ">=0.54.0"
   },

--- a/forge/mods.toml
+++ b/forge/mods.toml
@@ -17,7 +17,7 @@ license = "LGPL-3"
 [[dependencies.architectury]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[@MINECRAFT_VERSION@,)"
+versionRange = "[@MINECRAFT_VERSION@]"
 ordering = "NONE"
 side = "BOTH"
 

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -17,7 +17,7 @@ license = "LGPL-3"
 [[dependencies.architectury]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.19,)"
+versionRange = "[1.19]"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
Should reduce the number of issues and support threads like #324.