### PR TITLE
Fix crash with EntityEvent.LIVING_CHECK_SPAWN on Forge

### DIFF
--- a/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
+++ b/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
@@ -272,10 +272,11 @@ public class EventHandlerImplCommon {
     public static void event(LivingSpawnEvent.CheckSpawn event) {
         EventResult result = EntityEvent.LIVING_CHECK_SPAWN.invoker().canSpawn(event.getEntityLiving(), event.getWorld(), event.getX(), event.getY(), event.getZ(), event.getSpawnReason(), event.getSpawner());
         if (result.interruptsFurtherEvaluation()) {
-            if (result.value() != null) {
-                event.setResult(result.value() == Boolean.TRUE ? Event.Result.ALLOW : Event.Result.DENY);
+            if(result.isEmpty()) {
+                event.setResult(Event.Result.DEFAULT);
+            } else {
+                event.setResult(result.value() ? Event.Result.ALLOW : Event.Result.DENY);
             }
-            event.setCanceled(true);
         }
     }
     

--- a/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
+++ b/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
@@ -272,7 +272,7 @@ public class EventHandlerImplCommon {
     public static void event(LivingSpawnEvent.CheckSpawn event) {
         EventResult result = EntityEvent.LIVING_CHECK_SPAWN.invoker().canSpawn(event.getEntityLiving(), event.getWorld(), event.getX(), event.getY(), event.getZ(), event.getSpawnReason(), event.getSpawner());
         if (result.interruptsFurtherEvaluation()) {
-            if(result.isEmpty()) {
+            if (result.isEmpty()) {
                 event.setResult(Event.Result.DEFAULT);
             } else {
                 event.setResult(result.value() ? Event.Result.ALLOW : Event.Result.DENY);


### PR DESCRIPTION
**Portability:** Can be ported to 1.19.2 without any issues.

Currently, returning a non-PASS result in LIVING_CHECK_SPAWN crashes on Forge, as the event does not support being cancelled and instead uses the Result system to determine whether to allow or deny the spawn. Whether this issue has just gone unnoticed since its introduction or whether Forge has recently made their system react more strongly to "unwanted" cancellations, I don't know, but this PR should fix that issue, as well as allow people to set a "force default" state through interruptDefault :P