### PR TITLE
Fix Loom 1.0 removals

### DIFF
--- a/common/src/main/java/dev/architectury/registry/ReloadListenerRegistry.java
+++ b/common/src/main/java/dev/architectury/registry/ReloadListenerRegistry.java
@@ -23,8 +23,8 @@ import dev.architectury.injectables.annotations.ExpectPlatform;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 

--- a/fabric/src/main/java/dev/architectury/registry/fabric/ReloadListenerRegistryImpl.java
+++ b/fabric/src/main/java/dev/architectury/registry/fabric/ReloadListenerRegistryImpl.java
@@ -28,8 +28,8 @@ import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.profiling.ProfilerFiller;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;

--- a/forge/src/main/java/dev/architectury/core/item/forge/imitator/ArchitecturyBucketItem.java
+++ b/forge/src/main/java/dev/architectury/core/item/forge/imitator/ArchitecturyBucketItem.java
@@ -25,8 +25,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
 public class ArchitecturyBucketItem extends BucketItem {

--- a/forge/src/main/java/dev/architectury/platform/forge/PlatformImpl.java
+++ b/forge/src/main/java/dev/architectury/platform/forge/PlatformImpl.java
@@ -31,9 +31,9 @@ import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
 import net.minecraftforge.forgespi.language.IModFileInfo;
 import net.minecraftforge.forgespi.language.IModInfo;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -100,25 +100,25 @@ public class PlatformImpl {
         }
         
         @Override
-        @Nonnull
+        @NotNull
         public String getModId() {
             return info.getModId();
         }
         
         @Override
-        @Nonnull
+        @NotNull
         public String getVersion() {
             return info.getVersion().toString();
         }
         
         @Override
-        @Nonnull
+        @NotNull
         public String getName() {
             return info.getDisplayName();
         }
         
         @Override
-        @Nonnull
+        @NotNull
         public String getDescription() {
             return info.getDescription();
         }

--- a/forge/src/main/java/dev/architectury/registry/forge/CreativeTabRegistryImpl.java
+++ b/forge/src/main/java/dev/architectury/registry/forge/CreativeTabRegistryImpl.java
@@ -22,15 +22,15 @@ package dev.architectury.registry.forge;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.function.Supplier;
 
 public class CreativeTabRegistryImpl {
     public static CreativeModeTab create(ResourceLocation resourceLocation, Supplier<ItemStack> supplier) {
         return new CreativeModeTab(String.format("%s.%s", resourceLocation.getNamespace(), resourceLocation.getPath())) {
             @Override
-            @Nonnull
+            @NotNull
             public ItemStack makeIcon() {
                 return supplier.get();
             }

--- a/forge/src/main/java/dev/architectury/registry/forge/ReloadListenerRegistryImpl.java
+++ b/forge/src/main/java/dev/architectury/registry/forge/ReloadListenerRegistryImpl.java
@@ -31,8 +31,8 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 

--- a/testmod-forge/build.gradle
+++ b/testmod-forge/build.gradle
@@ -6,14 +6,14 @@ plugins {
 loom {
     accessWidenerPath = project(":common").loom.accessWidenerPath
 
+    mods {
+        forge {
+            sourceSet project(":forge").sourceSets.main
+        }
+    }
+
     forge {
         mixinConfig "architectury.mixins.json"
-
-        localMods {
-            forge {
-                it.add(project(":forge").sourceSets.main)
-            }
-        }
     }
 }
 


### PR DESCRIPTION
- javax annotations were accidentally available because of a transitive dep of Minecraft. Loom 0.13 blocks them since the launcher doesn't download them either.
- `forge.localMods` DSL was removed in favour of just `mods`