### PR TITLE
Fix injection point on lightning strike event

### DIFF
--- a/common/src/main/java/dev/architectury/mixin/MixinLightningBolt.java
+++ b/common/src/main/java/dev/architectury/mixin/MixinLightningBolt.java
@@ -43,7 +43,7 @@ public abstract class MixinLightningBolt extends Entity {
     @Inject(method = "tick", at = @At(
             value = "INVOKE_ASSIGN",
             target = "Lnet/minecraft/world/level/Level;getEntities(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;",
-            ordinal = 0,
+            ordinal = 1,
             shift = At.Shift.BY,
             by = 1
     ), locals = LocalCapture.CAPTURE_FAILHARD)


### PR DESCRIPTION
So, as it turns out, the point at which we currently inject for our lightning strike event means that the entities have already been marked as hit by it (and potentially gotten hurt / died), and the list of entities instead consists of all entities within a 15 block radius *not* yet hit by lightning(?), which both seems counterproductive and does not match the description of the corresponding event.

By moving the injection point to the *second* getEntities call, we get the desired result, though as a side effect the event will be called multiple times in a lightning bolt's lifetime (well, twice, as they live for two ticks before dying)