### PR TITLE
fix: Fabric BlockItem mixin: fire BlockEvent.PLACE at method head

### DIFF
--- a/fabric/src/main/java/dev/architectury/mixin/fabric/MixinBlockItem.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/MixinBlockItem.java
@@ -31,8 +31,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(BlockItem.class)
 public abstract class MixinBlockItem {
     @Inject(method = "place",
-            at = @At(value = "INVOKE",
-                    target = "Lnet/minecraft/world/item/context/BlockPlaceContext;getClickedPos()Lnet/minecraft/core/BlockPos;"),
+            at = @At("HEAD"),
             cancellable = true)
     private void place(BlockPlaceContext context, CallbackInfoReturnable<InteractionResult> cir) {
         var result = BlockEvent.PLACE.invoker().placeBlock(context.getLevel(), context.getClickedPos(), context.getLevel().getBlockState(context.getClickedPos()), context.getPlayer());


### PR DESCRIPTION
Currently, the mixin fires the event after the block has been placed