### PR TITLE
Update Fabric Loader to latest version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ archives_base_name_snapshot=architectury-snapshot
 base_version=4.11
 maven_group=dev.architectury
 
-fabric_loader_version=0.13.3
+fabric_loader_version=0.14.19
 fabric_api_version=0.58.0+1.18.2
 mod_menu_version=3.0.0
 


### PR DESCRIPTION
Fixes duplicate copies of Loader (pre-0.14 and post-0.14) ending up on the runtime classpath of API users and prevents a crash.

(Some patch release of Fabric Loader 0.14 opted out of Loom's remapping, which leads to one "remapped" and one non-remapped version of Fabric Loader being on the classpath.)

Requires forward porting to 1.19.x.