### PR TITLE
Update depend game version in mods.toml to 1.20

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[44,)"
+loaderVersion = "[46,)"
 issueTrackerURL = "https://github.com/shedaniel/architectury/issues"
 license = "GNU LGPLv3"
 
@@ -17,13 +17,13 @@ license = "LGPL-3"
 [[dependencies.architectury]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.19.3,)"
+versionRange = "[1.20,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.architectury]]
 modId = "forge"
 mandatory = true
-versionRange = "[44.0.6,)"
+versionRange = "[46,)"
 ordering = "NONE"
 side = "BOTH"


### PR DESCRIPTION
When I tried to develop 1.20 mod using architectury, I found the architectury api forge 9.0.7 still 1.19.3 and fml 44.  
It caused game crash in dev and prod environment.  
Is it by mistake?