### PR TITLE
Fix tooltip color event

### DIFF
--- a/common/src/main/java/dev/architectury/event/events/client/ClientTooltipEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/client/ClientTooltipEvent.java
@@ -52,7 +52,7 @@ public interface ClientTooltipEvent {
     /**
      * @see RenderModifyColor#renderTooltip(PoseStack, int, int, ColorContext)
      */
-    // Event<RenderModifyColor> RENDER_MODIFY_COLOR = EventFactory.createLoop();
+    Event<RenderModifyColor> RENDER_MODIFY_COLOR = EventFactory.createLoop();
     
     static AdditionalContexts additionalContexts() {
         return TooltipAdditionalContextsImpl.get();

--- a/common/src/main/java/dev/architectury/impl/TooltipEventColorContextImpl.java
+++ b/common/src/main/java/dev/architectury/impl/TooltipEventColorContextImpl.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public class TooltipEventColorContextImpl implements ClientTooltipEvent.ColorContext {
+    public static ThreadLocal<TooltipEventColorContextImpl> tooltipColorContext = ThreadLocal.withInitial(TooltipEventColorContextImpl::new);
     private int backgroundColor;
     private int outlineGradientTopColor;
     private int outlineGradientBottomColor;

--- a/common/src/main/java/dev/architectury/impl/TooltipEventColorContextImpl.java
+++ b/common/src/main/java/dev/architectury/impl/TooltipEventColorContextImpl.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public class TooltipEventColorContextImpl implements ClientTooltipEvent.ColorContext {
-    public static ThreadLocal<TooltipEventColorContextImpl> tooltipColorContext = ThreadLocal.withInitial(TooltipEventColorContextImpl::new);
+    public static final ThreadLocal<TooltipEventColorContextImpl> CONTEXT = ThreadLocal.withInitial(TooltipEventColorContextImpl::new);
     private int backgroundColor;
     private int outlineGradientTopColor;
     private int outlineGradientBottomColor;

--- a/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinScreen.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinScreen.java
@@ -97,7 +97,7 @@ public abstract class MixinScreen implements ScreenInputDelegate {
     @Inject(method = "renderTooltipInternal", at = @At("HEAD"), cancellable = true)
     private void renderTooltip(PoseStack poseStack, List<? extends ClientTooltipComponent> list, int x, int y, ClientTooltipPositioner positioner, CallbackInfo ci) {
         if (!list.isEmpty()) {
-            var colorContext = TooltipEventColorContextImpl.tooltipColorContext.get();
+            var colorContext = TooltipEventColorContextImpl.CONTEXT.get();
             colorContext.reset();
             var positionContext = tooltipPositionContext.get();
             positionContext.reset(x, y);

--- a/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinScreen.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinScreen.java
@@ -46,8 +46,6 @@ public abstract class MixinScreen implements ScreenInputDelegate {
     @Unique
     private static ThreadLocal<TooltipEventPositionContextImpl> tooltipPositionContext = ThreadLocal.withInitial(TooltipEventPositionContextImpl::new);
     @Unique
-    private static ThreadLocal<TooltipEventColorContextImpl> tooltipColorContext = ThreadLocal.withInitial(TooltipEventColorContextImpl::new);
-    @Unique
     private ScreenAccessImpl access;
     
     @Shadow
@@ -99,14 +97,14 @@ public abstract class MixinScreen implements ScreenInputDelegate {
     @Inject(method = "renderTooltipInternal", at = @At("HEAD"), cancellable = true)
     private void renderTooltip(PoseStack poseStack, List<? extends ClientTooltipComponent> list, int x, int y, ClientTooltipPositioner positioner, CallbackInfo ci) {
         if (!list.isEmpty()) {
-            var colorContext = tooltipColorContext.get();
+            var colorContext = TooltipEventColorContextImpl.tooltipColorContext.get();
             colorContext.reset();
             var positionContext = tooltipPositionContext.get();
             positionContext.reset(x, y);
             if (ClientTooltipEvent.RENDER_PRE.invoker().renderTooltip(poseStack, list, x, y).isFalse()) {
                 ci.cancel();
             } else {
-                // ClientTooltipEvent.RENDER_MODIFY_COLOR.invoker().renderTooltip(poseStack, x, y, colorContext);
+                ClientTooltipEvent.RENDER_MODIFY_COLOR.invoker().renderTooltip(poseStack, x, y, colorContext);
                 ClientTooltipEvent.RENDER_MODIFY_POSITION.invoker().renderTooltip(poseStack, positionContext);
             }
         }
@@ -123,19 +121,4 @@ public abstract class MixinScreen implements ScreenInputDelegate {
     private int modifyTooltipY(int original) {
         return tooltipPositionContext.get().getTooltipY();
     }
-    
-    // @ModifyConstant(method = "renderTooltipInternal", constant = @Constant(intValue = 0xf0100010))
-    // private int modifyTooltipBackgroundColor(int original) {
-    //     return tooltipColorContext.get().getBackgroundColor();
-    // }
-    
-    // @ModifyConstant(method = "renderTooltipInternal", constant = @Constant(intValue = 0x505000ff))
-    // private int modifyTooltipOutlineGradientTopColor(int original) {
-    //     return tooltipColorContext.get().getOutlineGradientTopColor();
-    // }
-    
-    // @ModifyConstant(method = "renderTooltipInternal", constant = @Constant(intValue = 0x5028007f))
-    // private int modifyTooltipOutlineGradientBottomColor(int original) {
-    //     return tooltipColorContext.get().getOutlineGradientBottomColor();
-    // }
 }

--- a/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinTooltipRenderUtil.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinTooltipRenderUtil.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.mixin.fabric.client;
+
+import dev.architectury.impl.TooltipEventColorContextImpl;
+import net.minecraft.client.gui.screens.inventory.tooltip.TooltipRenderUtil;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(TooltipRenderUtil.class)
+public abstract class MixinTooltipRenderUtil {
+    @ModifyConstant(method = "renderTooltipBackground", constant = @Constant(intValue = 0xf0100010))
+    private static int modifyTooltipBackgroundColor(int original) {
+        return TooltipEventColorContextImpl.tooltipColorContext.get().getBackgroundColor();
+    }
+    
+    @ModifyConstant(method = "renderTooltipBackground", constant = @Constant(intValue = 0x505000ff))
+    private static int modifyTooltipOutlineGradientTopColor(int original) {
+        return TooltipEventColorContextImpl.tooltipColorContext.get().getOutlineGradientTopColor();
+    }
+    
+    @ModifyConstant(method = "renderTooltipBackground", constant = @Constant(intValue = 0x5028007f))
+    private static int modifyTooltipOutlineGradientBottomColor(int original) {
+        return TooltipEventColorContextImpl.tooltipColorContext.get().getOutlineGradientBottomColor();
+    }
+}

--- a/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinTooltipRenderUtil.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinTooltipRenderUtil.java
@@ -29,16 +29,16 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 public abstract class MixinTooltipRenderUtil {
     @ModifyConstant(method = "renderTooltipBackground", constant = @Constant(intValue = 0xf0100010))
     private static int modifyTooltipBackgroundColor(int original) {
-        return TooltipEventColorContextImpl.tooltipColorContext.get().getBackgroundColor();
+        return TooltipEventColorContextImpl.CONTEXT.get().getBackgroundColor();
     }
     
     @ModifyConstant(method = "renderTooltipBackground", constant = @Constant(intValue = 0x505000ff))
     private static int modifyTooltipOutlineGradientTopColor(int original) {
-        return TooltipEventColorContextImpl.tooltipColorContext.get().getOutlineGradientTopColor();
+        return TooltipEventColorContextImpl.CONTEXT.get().getOutlineGradientTopColor();
     }
     
     @ModifyConstant(method = "renderTooltipBackground", constant = @Constant(intValue = 0x5028007f))
     private static int modifyTooltipOutlineGradientBottomColor(int original) {
-        return TooltipEventColorContextImpl.tooltipColorContext.get().getOutlineGradientBottomColor();
+        return TooltipEventColorContextImpl.CONTEXT.get().getOutlineGradientBottomColor();
     }
 }

--- a/fabric/src/main/resources/architectury.mixins.json
+++ b/fabric/src/main/resources/architectury.mixins.json
@@ -19,6 +19,7 @@
     "client.MixinMouseHandler",
     "client.MixinMultiPlayerGameMode",
     "client.MixinScreen",
+    "client.MixinTooltipRenderUtil"
   ],
   "mixins": [
     "BiomeAccessor",

--- a/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplClient.java
+++ b/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplClient.java
@@ -201,7 +201,7 @@ public class EventHandlerImplClient {
         ClientTooltipEvent.additionalContexts().setItem(event.getItemStack());
         
         try {
-            TooltipEventColorContextImpl colorContext = TooltipEventColorContextImpl.tooltipColorContext.get();
+            TooltipEventColorContextImpl colorContext = TooltipEventColorContextImpl.CONTEXT.get();
             colorContext.reset();
             colorContext.setBackgroundColor(event.getBackgroundStart());
             colorContext.setOutlineGradientTopColor(event.getBorderStart());

--- a/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplClient.java
+++ b/forge/src/main/java/dev/architectury/event/forge/EventHandlerImplClient.java
@@ -172,7 +172,6 @@ public class EventHandlerImplClient {
         ClientRecipeUpdateEvent.EVENT.invoker().update(event.getRecipeManager());
     }
     
-    private static final ThreadLocal<TooltipEventColorContextImpl> tooltipColorContext = ThreadLocal.withInitial(TooltipEventColorContextImpl::new);
     private static final ThreadLocal<TooltipEventPositionContextImpl> tooltipPositionContext = ThreadLocal.withInitial(TooltipEventPositionContextImpl::new);
     
     @SubscribeEvent(priority = EventPriority.HIGH)
@@ -202,12 +201,12 @@ public class EventHandlerImplClient {
         ClientTooltipEvent.additionalContexts().setItem(event.getItemStack());
         
         try {
-            TooltipEventColorContextImpl colorContext = tooltipColorContext.get();
+            TooltipEventColorContextImpl colorContext = TooltipEventColorContextImpl.tooltipColorContext.get();
             colorContext.reset();
             colorContext.setBackgroundColor(event.getBackgroundStart());
             colorContext.setOutlineGradientTopColor(event.getBorderStart());
             colorContext.setOutlineGradientBottomColor(event.getBorderEnd());
-            // ClientTooltipEvent.RENDER_MODIFY_COLOR.invoker().renderTooltip(stack, event.getX(), event.getY(), colorContext);
+            ClientTooltipEvent.RENDER_MODIFY_COLOR.invoker().renderTooltip(stack, event.getX(), event.getY(), colorContext);
             event.setBackground(colorContext.getBackgroundColor());
             event.setBorderEnd(colorContext.getOutlineGradientBottomColor());
             event.setBorderStart(colorContext.getOutlineGradientTopColor());

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -17,13 +17,13 @@ license = "LGPL-3"
 [[dependencies.architectury]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.19.3,)"
+versionRange = "[1.19.4,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.architectury]]
 modId = "forge"
 mandatory = true
-versionRange = "[44.0.6,)"
+versionRange = "[45.1.0,)"
 ordering = "NONE"
 side = "BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ fabric_loader_version=0.14.19
 fabric_api_version=0.76.0+1.19.4
 mod_menu_version=5.0.2
 
-forge_version=45.0.24
+forge_version=45.1.0
 
 curseforge_id=419699
 modrinth_id=lhGA9TYQ

--- a/testmod-common/src/main/java/dev/architectury/test/events/DebugEvents.java
+++ b/testmod-common/src/main/java/dev/architectury/test/events/DebugEvents.java
@@ -350,6 +350,11 @@ public class DebugEvents {
             TestMod.SINK.accept("Screen has been changed to " + toSimpleName(screen));
             return CompoundEventResult.pass();
         });
+        ClientTooltipEvent.RENDER_MODIFY_COLOR.register((matrices, x, y, context) -> {
+            context.setBackgroundColor(0xf0ffeded);
+            context.setOutlineGradientTopColor(0xf0ff5c5c);
+            context.setOutlineGradientBottomColor(0xf0f74d4d);
+        });
     }
     
     private static String chunkPos(int x, int z) {


### PR DESCRIPTION
I removed this event back in the 1.19.3 port since Forge removed its event. Now that Forge has finally added it back (in May), this PR adds the event back.

### About version support
Since Forge has only fixed this issue on 1.19.4, this PR will not be backported to 1.19.3.
Looking at the grand scheme of things, I propose that we move forward with the following:
- API 4: 1.18.2
- ~~API 5: 1.19 - 1.19.1~~ **(drop support here)**
- API 6: 1.19.2
- ~~API 7: 1.19.3~~ **(drop support here)**
- API 8: 1.19.4
- API 9: 1.20 - 1.20.1

### Test Mod
I have added a simple test mod:
![image](https://github.com/architectury/architectury-api/assets/34910653/7c8692b6-6b8d-4926-b814-6f57f79b7def)
