### PR TITLE
Fix INIT_POST not being invoked

### DIFF
--- a/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinScreen.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinScreen.java
@@ -72,7 +72,7 @@ public abstract class MixinScreen implements ScreenInputDelegate {
     }
     
     @Inject(method = "rebuildWidgets", at = @At(value = "RETURN"))
-    private void postInit(CallbackInfo ci ) {
+    private void postInit(CallbackInfo ci) {
         ClientGuiEvent.INIT_POST.invoker().init((Screen) (Object) this, getAccess());
     }
 }

--- a/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinScreen.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinScreen.java
@@ -71,8 +71,8 @@ public abstract class MixinScreen implements ScreenInputDelegate {
         }
     }
     
-    @Inject(method = "init(Lnet/minecraft/client/Minecraft;II)V", at = @At(value = "RETURN"))
-    private void postInit(Minecraft minecraft, int i, int j, CallbackInfo ci) {
+    @Inject(method = "rebuildWidgets", at = @At(value = "RETURN"))
+    private void postInit(CallbackInfo ci ) {
         ClientGuiEvent.INIT_POST.invoker().init((Screen) (Object) this, getAccess());
     }
 }

--- a/testmod-common/src/main/java/dev/architectury/test/events/DebugEvents.java
+++ b/testmod-common/src/main/java/dev/architectury/test/events/DebugEvents.java
@@ -290,6 +290,9 @@ public class DebugEvents {
             TestMod.SINK.accept(toSimpleName(screen) + " initializes");
             return EventResult.pass();
         });
+        ClientGuiEvent.INIT_POST.register(((screen, access) -> {
+            TestMod.SINK.accept(toSimpleName(screen) + " initialized");
+        }));
         InteractionEvent.CLIENT_LEFT_CLICK_AIR.register((player, hand) -> {
             TestMod.SINK.accept(player.getScoreboardName() + " left clicks air" + logSide(player.level()));
         });


### PR DESCRIPTION
Closes #416 

When porting to 1.20 the INIT_PRE mixin target method was changed but the INIT_POST event seems to have only been added after or just forgotten