### PR TITLE
Make ArchitecturyFlowingFluid use the same Forge FluidType when the s…

### DIFF
--- a/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFlowingFluid.java
+++ b/forge/src/main/java/dev/architectury/core/fluid/forge/imitator/ArchitecturyFlowingFluid.java
@@ -20,7 +20,6 @@
 package dev.architectury.core.fluid.forge.imitator;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import dev.architectury.core.fluid.ArchitecturyFluidAttributes;
 import net.minecraft.core.BlockPos;
@@ -43,7 +42,6 @@ import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;


### PR DESCRIPTION
…ame ArchitecturyFluidAttributes object is passed in.

This fixes https://github.com/architectury/architectury-api/issues/447. This is the smallest change I could come up with. The only other way I could see to fix it would be to create a Forge  specific version of the SimpleArchitecturyFluidAttributes class that contained a `toForgeType` or `getForgeType`, that cached the value itself, but you'd have to cast it, because the interface type is used for the AFF constructor, and we don't want Forge specific types in the interface, unless we also make a forge specific version of the interface, and that just seems to be getting out of control.. I think this is a nice clean solution to the issue. 