### PR TITLE
fix: FluidStackImpl#getRawFluidSupplier crashing on forge/neoforge

### DIFF
--- a/forge/src/main/java/dev/architectury/fluid/forge/FluidStackImpl.java
+++ b/forge/src/main/java/dev/architectury/fluid/forge/FluidStackImpl.java
@@ -54,7 +54,7 @@ public enum FluidStackImpl implements dev.architectury.fluid.FluidStack.FluidSta
     
     @Override
     public Supplier<Fluid> getRawFluidSupplier(FluidStack object) {
-        return BuiltInRegistries.FLUID.getHolderOrThrow(BuiltInRegistries.FLUID.getResourceKey(object.getRawFluid()).orElseThrow());
+        return () -> BuiltInRegistries.FLUID.getHolderOrThrow(BuiltInRegistries.FLUID.getResourceKey(object.getRawFluid()).orElseThrow()).value();
     }
     
     @Override


### PR DESCRIPTION
Wrap the `Holder.Reference` returned from `Registry#getHolderOrThrow` in an actual `Supplier`

`Holder.Reference` does not implement `Supplier` so attempting to create a fluidstack currently crashes:

```
Caused by: java.lang.IncompatibleClassChangeError: Class net.minecraft.core.Holder$Reference does not implement the requested interface java.util.function.Supplier
    at dev.architectury.fluid.forge.FluidStackImpl.create(FluidStackImpl.java:52) ~[architectury-neoforge-11.1.13.jar%23177!/:?] {re:classloading}
    at dev.architectury.fluid.forge.FluidStackImpl.create(FluidStackImpl.java:33) ~[architectury-neoforge-11.1.13.jar%23177!/:?] {re:classloading}
    at dev.architectury.fluid.FluidStack.<init>(FluidStack.java:44) ~[architectury-neoforge-11.1.13.jar%23177!/:?] {re:classloading}
    at dev.architectury.fluid.FluidStack.copyWithAmount(FluidStack.java:245) ~[architectury-neoforge-11.1.13.jar%23177!/:?] {re:classloading}
    at
...
```
