### PR TITLE
Backported fluid stack fix to 1.20.2

### DIFF
--- a/forge/src/main/java/dev/architectury/fluid/forge/FluidStackImpl.java
+++ b/forge/src/main/java/dev/architectury/fluid/forge/FluidStackImpl.java
@@ -54,7 +54,7 @@ public enum FluidStackImpl implements dev.architectury.fluid.FluidStack.FluidSta
     
     @Override
     public Supplier<Fluid> getRawFluidSupplier(FluidStack object) {
-        return BuiltInRegistries.FLUID.getHolderOrThrow(BuiltInRegistries.FLUID.getResourceKey(object.getRawFluid()).orElseThrow());
+        return () -> BuiltInRegistries.FLUID.getHolderOrThrow(BuiltInRegistries.FLUID.getResourceKey(object.getRawFluid()).orElseThrow()).value();
     }
     
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ fabric_api_version=0.89.1+1.20.2
 mod_menu_version=7.0.0
 
 forge_version=48.0.38
-neoforge_version=20.2.59-beta
+neoforge_version=20.2.88
 
 curseforge_id=419699
 modrinth_id=lhGA9TYQ


### PR DESCRIPTION
fix: FluidStackImpl#getRawFluidSupplier crashing on forge/neoforge