### PR TITLE
Add Codecs to Registrar

### DIFF
--- a/common/src/main/java/dev/architectury/registry/registries/Registrar.java
+++ b/common/src/main/java/dev/architectury/registry/registries/Registrar.java
@@ -19,6 +19,7 @@
 
 package dev.architectury.registry.registries;
 
+import com.mojang.serialization.Codec;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -76,6 +77,10 @@ public interface Registrar<T> extends Iterable<T> {
     default Holder<T> getHolder(ResourceLocation id) {
         return getHolder(ResourceKey.create(key(), id));
     }
+    
+    Codec<T> codec();
+    
+    Codec<Holder<T>> holderCodec();
     
     /**
      * Listens to when the registry entry is registered, and calls the given action.

--- a/fabric/src/main/java/dev/architectury/registry/registries/fabric/RegistrarManagerImpl.java
+++ b/fabric/src/main/java/dev/architectury/registry/registries/fabric/RegistrarManagerImpl.java
@@ -23,6 +23,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import com.mojang.serialization.Codec;
 import dev.architectury.impl.RegistrySupplierImpl;
 import dev.architectury.registry.registries.Registrar;
 import dev.architectury.registry.registries.RegistrarBuilder;
@@ -287,6 +288,16 @@ public class RegistrarManagerImpl {
         @Nullable
         public Holder<T> getHolder(ResourceKey<T> key) {
             return delegate.getHolder(key).orElse(null);
+        }
+        
+        @Override
+        public Codec<T> codec() {
+            return delegate.byNameCodec();
+        }
+        
+        @Override
+        public Codec<Holder<T>> holderCodec() {
+            return delegate.holderByNameCodec();
         }
         
         @Override

--- a/neoforge/src/main/java/dev/architectury/registry/registries/forge/RegistrarManagerImpl.java
+++ b/neoforge/src/main/java/dev/architectury/registry/registries/forge/RegistrarManagerImpl.java
@@ -23,6 +23,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import com.mojang.serialization.Codec;
 import dev.architectury.impl.RegistrySupplierImpl;
 import dev.architectury.platform.hooks.EventBusesHooks;
 import dev.architectury.registry.registries.Registrar;
@@ -395,6 +396,16 @@ public class RegistrarManagerImpl {
         @Nullable
         public Holder<T> getHolder(ResourceKey<T> key) {
             return delegate.getHolder(key).orElse(null);
+        }
+        
+        @Override
+        public Codec<T> codec() {
+            return delegate.byNameCodec();
+        }
+        
+        @Override
+        public Codec<Holder<T>> holderCodec() {
+            return delegate.holderByNameCodec();
         }
         
         @Override


### PR DESCRIPTION
I noticed that registries provide a Codec<T> and Codec<Holder<T>. Since a Registry is wrapped by a Registrar, why not have a Registrar provide the same codecs?