### PR TITLE
Update Architectury for new Neoforge 21.0.31 entity damage pipeline

### DIFF
--- a/common/src/main/java/dev/architectury/event/events/common/EntityEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/common/EntityEvent.java
@@ -76,7 +76,7 @@ public interface EntityEvent {
     interface LivingHurt {
         /**
          * Invoked before an entity is hurt by a damage source.
-         * Equivalent to Forge's {@code LivingAttackEvent} event.
+         * Equivalent to NeoForge's {@code LivingIncomingDamageEvent} or Forge's {@code LivingAttackEvent} event.
          *
          * <p>You currently cannot override the amount of damage the entity receives.
          *

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ fabric_api_version=0.100.0+1.21
 mod_menu_version=10.0.0-beta.1
 
 forge_version=51.0.0
-neoforge_version=21.0.0-beta
+neoforge_version=21.0.31-beta
 
 # Set to empty if not snapshots
 neoforge_pr=

--- a/neoforge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
+++ b/neoforge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
@@ -23,7 +23,6 @@ import dev.architectury.event.CompoundEventResult;
 import dev.architectury.event.EventResult;
 import dev.architectury.event.events.common.PlayerEvent;
 import dev.architectury.event.events.common.*;
-import dev.architectury.utils.value.IntValue;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
@@ -32,7 +31,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
-import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -41,15 +39,12 @@ import net.neoforged.neoforge.event.CommandEvent;
 import net.neoforged.neoforge.event.LootTableLoadEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.ServerChatEvent;
-import net.neoforged.neoforge.event.tick.LevelTickEvent;
-import net.neoforged.neoforge.event.tick.PlayerTickEvent;
-import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
 import net.neoforged.neoforge.event.entity.item.ItemTossEvent;
 import net.neoforged.neoforge.event.entity.living.AnimalTameEvent;
 import net.neoforged.neoforge.event.entity.living.FinalizeSpawnEvent;
-import net.neoforged.neoforge.event.entity.living.LivingAttackEvent;
 import net.neoforged.neoforge.event.entity.living.LivingDeathEvent;
+import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
 import net.neoforged.neoforge.event.entity.player.*;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent.*;
 import net.neoforged.neoforge.event.level.BlockEvent.BreakEvent;
@@ -60,6 +55,9 @@ import net.neoforged.neoforge.event.level.ExplosionEvent.Detonate;
 import net.neoforged.neoforge.event.level.ExplosionEvent.Start;
 import net.neoforged.neoforge.event.level.LevelEvent;
 import net.neoforged.neoforge.event.server.*;
+import net.neoforged.neoforge.event.tick.LevelTickEvent;
+import net.neoforged.neoforge.event.tick.PlayerTickEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 
 public class EventHandlerImplCommon {
@@ -228,7 +226,7 @@ public class EventHandlerImplCommon {
     }
     
     @SubscribeEvent(priority = EventPriority.HIGH)
-    public static void event(LivingAttackEvent event) {
+    public static void event(LivingIncomingDamageEvent event) {
         if (EntityEvent.LIVING_HURT.invoker().hurt(event.getEntity(), event.getSource(), event.getAmount()).isFalse()) {
             event.setCanceled(true);
         }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -24,7 +24,7 @@ side = "BOTH"
 [[dependencies.architectury]]
 modId = "neoforge"
 type = "required"
-versionRange = "[20.1.0-beta,)"
+versionRange = "[20.1.31-beta,)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
Updates Arch for a breaking change in NeoForge 21.0.31-beta

See https://neoforged.net/news/21.0release/#damage-pipeline-rework-introduced-in-neoforge-21031-beta for more information.

The change is simple; use Neo's `LivingIncomingDamageEvent` instead of the old `LivingAttackEvent`, which no longer exists.