### PR TITLE
Register SpawnEntityPacket on Fabric server 1.21

### DIFF
--- a/fabric/src/main/java/dev/architectury/init/fabric/ArchitecturyServer.java
+++ b/fabric/src/main/java/dev/architectury/init/fabric/ArchitecturyServer.java
@@ -20,9 +20,12 @@
 package dev.architectury.init.fabric;
 
 import dev.architectury.event.events.common.LifecycleEvent;
+import dev.architectury.networking.SpawnEntityPacket;
 
 public class ArchitecturyServer {
     public static void init() {
         LifecycleEvent.SETUP.invoker().run();
+        
+        SpawnEntityPacket.register();
     }
 }


### PR DESCRIPTION
Fixes #523 

This fix also needs to be applied on all other susceptible versions (see #525 and #526)
