### PR TITLE
[1.21] Use RegistryFriendlyByteBuf for extended menus

### DIFF
--- a/common/src/main/java/dev/architectury/registry/menu/ExtendedMenuProvider.java
+++ b/common/src/main/java/dev/architectury/registry/menu/ExtendedMenuProvider.java
@@ -19,9 +19,9 @@
 
 package dev.architectury.registry.menu;
 
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.MenuProvider;
 
 public interface ExtendedMenuProvider extends MenuProvider {
-    void saveExtraData(FriendlyByteBuf buf);
+    void saveExtraData(RegistryFriendlyByteBuf buf);
 }

--- a/common/src/main/java/dev/architectury/registry/menu/MenuRegistry.java
+++ b/common/src/main/java/dev/architectury/registry/menu/MenuRegistry.java
@@ -25,6 +25,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.MenuAccess;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.MenuProvider;
@@ -50,10 +51,10 @@ public final class MenuRegistry {
      * @param provider  The {@link MenuProvider} that provides the menu
      * @param bufWriter That writer that sends extra data for {@link MenuType} created with {@link MenuRegistry#ofExtended(ExtendedMenuTypeFactory)}
      */
-    public static void openExtendedMenu(ServerPlayer player, MenuProvider provider, Consumer<FriendlyByteBuf> bufWriter) {
+    public static void openExtendedMenu(ServerPlayer player, MenuProvider provider, Consumer<RegistryFriendlyByteBuf> bufWriter) {
         openExtendedMenu(player, new ExtendedMenuProvider() {
             @Override
-            public void saveExtraData(FriendlyByteBuf buf) {
+            public void saveExtraData(RegistryFriendlyByteBuf buf) {
                 bufWriter.accept(buf);
             }
             
@@ -183,6 +184,6 @@ public final class MenuRegistry {
          * @param buf       The {@link FriendlyByteBuf} for the menu to provide extra data
          * @return A new {@link T} that extends {@link AbstractContainerMenu}
          */
-        T create(int id, Inventory inventory, FriendlyByteBuf buf);
+        T create(int id, Inventory inventory, RegistryFriendlyByteBuf buf);
     }
 }

--- a/fabric/src/main/java/dev/architectury/registry/menu/fabric/MenuRegistryImpl.java
+++ b/fabric/src/main/java/dev/architectury/registry/menu/fabric/MenuRegistryImpl.java
@@ -27,13 +27,13 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.MenuAccess;
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.server.level.ServerPlayer;
@@ -51,7 +51,8 @@ public class MenuRegistryImpl {
         player.openMenu(new ExtendedScreenHandlerFactory<byte[]>() {
             @Override
             public byte[] getScreenOpeningData(ServerPlayer player) {
-                FriendlyByteBuf buf = PacketByteBufs.create();
+                RegistryAccess access = player.registryAccess();
+                RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.buffer(), access);
                 provider.saveExtraData(buf);
                 byte[] bytes = ByteBufUtil.getBytes(buf);
                 buf.release();
@@ -77,7 +78,8 @@ public class MenuRegistryImpl {
     
     public static <T extends AbstractContainerMenu> MenuType<T> ofExtended(ExtendedMenuTypeFactory<T> factory) {
         return new ExtendedScreenHandlerType<>((syncId, inventory, data) -> {
-            FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.wrappedBuffer(data));
+            RegistryAccess access = inventory.player.registryAccess();
+            RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.wrappedBuffer(data), access);
             T menu = factory.create(syncId, inventory, buf);
             buf.release();
             return menu;


### PR DESCRIPTION
Extended menus use `FriendlyByteBuf`, so they can't be used with StreamCodecs to serialize things as they require a `RegistryFriendlyByteBuf`.

Forge and NeoForge already use `RegistryFriendlyByteBuf` natively when calling `player.openMenu`, but Fabric's implementation is more custom on the Architectury side and it creates a `FriendlyByteBuf`.

This PR changes all `FriendlyByteBuf` into `RegistryFriendlyByteBuf` in all places I've seen it related to extended menus.