### PR TITLE
Use new NeoForge reload listeners

### DIFF
--- a/common/src/main/java/dev/architectury/registry/ReloadListenerRegistry.java
+++ b/common/src/main/java/dev/architectury/registry/ReloadListenerRegistry.java
@@ -31,17 +31,13 @@ import java.util.List;
 public final class ReloadListenerRegistry {
     private ReloadListenerRegistry() {
     }
-    
-    public static void register(PackType type, PreparableReloadListener listener) {
-        register(type, listener, null);
-    }
-    
-    public static void register(PackType type, PreparableReloadListener listener, @Nullable ResourceLocation listenerId) {
+
+    public static void register(PackType type, PreparableReloadListener listener, ResourceLocation listenerId) {
         register(type, listener, listenerId, List.of());
     }
     
     @ExpectPlatform
-    public static void register(PackType type, PreparableReloadListener listener, @Nullable ResourceLocation listenerId, Collection<ResourceLocation> dependencies) {
+    public static void register(PackType type, PreparableReloadListener listener, ResourceLocation listenerId, Collection<ResourceLocation> dependencies) {
         throw new AssertionError();
     }
 }

--- a/fabric/src/main/java/dev/architectury/registry/fabric/ReloadListenerRegistryImpl.java
+++ b/fabric/src/main/java/dev/architectury/registry/fabric/ReloadListenerRegistryImpl.java
@@ -38,7 +38,7 @@ import java.util.concurrent.Executor;
 public class ReloadListenerRegistryImpl {
     private static final SecureRandom RANDOM = new SecureRandom();
     
-    public static void register(PackType type, PreparableReloadListener listener, @Nullable ResourceLocation listenerId, Collection<ResourceLocation> dependencies) {
+    public static void register(PackType type, PreparableReloadListener listener, ResourceLocation listenerId, Collection<ResourceLocation> dependencies) {
         var bytes = new byte[8];
         RANDOM.nextBytes(bytes);
         var id = listenerId != null ? listenerId : ResourceLocation.parse("architectury:reload_" + StringUtils.leftPad(Math.abs(Longs.fromByteArray(bytes)) + "", 19, '0'));

--- a/forge/src/main/java/dev/architectury/registry/forge/ReloadListenerRegistryImpl.java
+++ b/forge/src/main/java/dev/architectury/registry/forge/ReloadListenerRegistryImpl.java
@@ -43,7 +43,7 @@ public class ReloadListenerRegistryImpl {
         MinecraftForge.EVENT_BUS.addListener(ReloadListenerRegistryImpl::addReloadListeners);
     }
     
-    public static void register(PackType type, PreparableReloadListener listener, @Nullable ResourceLocation listenerId, Collection<ResourceLocation> dependencies) {
+    public static void register(PackType type, PreparableReloadListener listener, ResourceLocation listenerId, Collection<ResourceLocation> dependencies) {
         if (type == PackType.SERVER_DATA) {
             serverDataReloadListeners.add(listener);
         } else if (type == PackType.CLIENT_RESOURCES) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ fabric_api_version=0.110.5+1.21.4
 mod_menu_version=11.0.1
 
 forge_version=51.0.0
-neoforge_version=21.4.0-beta
+neoforge_version=21.4.84-beta
 
 # Set to empty if not snapshots
 neoforge_pr=

--- a/neoforge/src/main/java/dev/architectury/registry/forge/ReloadListenerRegistryImpl.java
+++ b/neoforge/src/main/java/dev/architectury/registry/forge/ReloadListenerRegistryImpl.java
@@ -19,7 +19,12 @@
 
 package dev.architectury.registry.forge;
 
-import com.google.common.collect.Lists;
+import dev.architectury.platform.Platform;
+import dev.architectury.platform.hooks.EventBusesHooks;
+import dev.architectury.utils.ArchitecturyConstants;
+import dev.architectury.utils.Env;
+import dev.architectury.utils.EnvExecutor;
+import javax.annotation.Nullable;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
@@ -27,36 +32,49 @@ import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.neoforge.client.event.AddClientReloadListenersEvent;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.event.AddReloadListenerEvent;
-import org.jetbrains.annotations.Nullable;
+import net.neoforged.neoforge.event.AddServerReloadListenersEvent;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ReloadListenerRegistryImpl {
-    private static List<PreparableReloadListener> serverDataReloadListeners = Lists.newArrayList();
+    private static Map<ResourceLocation, PreparableReloadListener> clientDataReloadListeners = new HashMap<>();
+    private static Map<ResourceLocation, Collection<ResourceLocation>> clientDataReloadListenerDependencies = new HashMap<>();
+
+    private static Map<ResourceLocation, PreparableReloadListener> serverDataReloadListeners = new HashMap<>();
+    private static Map<ResourceLocation, Collection<ResourceLocation>> serverDataReloadListenerDependencies = new HashMap<>();
     
     static {
-        NeoForge.EVENT_BUS.addListener(ReloadListenerRegistryImpl::addReloadListeners);
+        EventBusesHooks.whenAvailable(ArchitecturyConstants.MOD_ID, bus -> {
+            if(Platform.getEnvironment() == Env.CLIENT) {
+                bus.addListener(ReloadListenerRegistryImpl::addClientReloadListeners);
+            }
+        });
+
+        NeoForge.EVENT_BUS.addListener(ReloadListenerRegistryImpl::addServerReloadListeners);
     }
     
-    public static void register(PackType type, PreparableReloadListener listener, @Nullable ResourceLocation listenerId, Collection<ResourceLocation> dependencies) {
+    public static void register(PackType type, PreparableReloadListener listener, ResourceLocation listenerId, Collection<ResourceLocation> dependencies) {
         if (type == PackType.SERVER_DATA) {
-            serverDataReloadListeners.add(listener);
+            serverDataReloadListeners.put(listenerId, listener);
+            serverDataReloadListenerDependencies.put(listenerId, dependencies);
         } else if (type == PackType.CLIENT_RESOURCES) {
-            registerClient(listener);
+            clientDataReloadListeners.put(listenerId, listener);
+            clientDataReloadListenerDependencies.put(listenerId, dependencies);
         }
     }
-    
+
     @OnlyIn(Dist.CLIENT)
-    private static void registerClient(PreparableReloadListener listener) {
-        ((ReloadableResourceManager) Minecraft.getInstance().getResourceManager()).registerReloadListener(listener);
+    public static void addClientReloadListeners(AddClientReloadListenersEvent event) {
+        clientDataReloadListeners.forEach(event::addListener);
+        clientDataReloadListenerDependencies.forEach((listener, dependencies) -> dependencies.forEach(dependency -> event.addDependency(listener, dependency)));
     }
-    
-    public static void addReloadListeners(AddReloadListenerEvent event) {
-        for (PreparableReloadListener listener : serverDataReloadListeners) {
-            event.addListener(listener);
-        }
+
+    public static void addServerReloadListeners(AddServerReloadListenersEvent event) {
+        serverDataReloadListeners.forEach(event::addListener);
+        serverDataReloadListenerDependencies.forEach((listener, dependencies) -> dependencies.forEach(dependency -> event.addDependency(listener, dependency)));
     }
 }


### PR DESCRIPTION
This change breaks mods that were using a null listenerId when calling `ReloadListenerRegistry.register(...)`, as NeoForge now requires that all listeners are named.

Summary of changes:
1. The ReloadListenerRegistry.register(PackType type, PreparableReloadListener listener) method has been removed.
2. For the remaining register(...) methods, the `ResourceLocation listenerId` is no longer `@Nullable`.
3. The `ReloadListenerRegistryImpl` for NeoForge now uses the appropriate events.
4. Architectury API now depends on a minimum version of `21.4.84-beta`.

See https://github.com/neoforged/NeoForge/pull/1915 for more information.