### PR TITLE
Port to 1.21.5 rc1

### DIFF
--- a/fabric/src/main/java/dev/architectury/mixin/fabric/MixinResultSlot.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/MixinResultSlot.java
@@ -42,7 +42,7 @@ public class MixinResultSlot {
     private CraftingContainer craftSlots;
     
     @Inject(method = "checkTakeAchievements", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/world/item/ItemStack;onCraftedBy(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;I)V",
+            target = "Lnet/minecraft/world/item/ItemStack;onCraftedBy(Lnet/minecraft/world/entity/player/Player;I)V",
             shift = At.Shift.AFTER))
     private void craft(ItemStack itemStack, CallbackInfo ci) {
         PlayerEvent.CRAFT_ITEM.invoker().craft(player, itemStack, craftSlots);

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.daemon=false
 
 platforms=fabric
 
-minecraft_version=1.21.5-pre2
-supported_version=1.21.5-pre2
+minecraft_version=1.21.5-rc1
+supported_version=1.21.5-rc1
 
 artifact_type=beta
 
@@ -15,7 +15,7 @@ maven_group=dev.architectury
 version_suffix=
 
 fabric_loader_version=0.16.10
-fabric_api_version=0.119.0+1.21.5
+fabric_api_version=0.119.3+1.21.5
 mod_menu_version=11.0.1
 
 forge_version=51.0.0


### PR DESCRIPTION
1.21.5-pre3 had a change to the target for the mixin in MixinResultSlot, which would cause the game to immediately crash.

Then bump to 1.21.5-rc1, no changes needed. Leaving it at Fabric API 0.119.3+1.21.5, as 0.119.4 includes breaking changes.