### PR TITLE
Fix PICKUP_ITEM_POST to obtain the original item stack

### DIFF
--- a/neoforge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
+++ b/neoforge/src/main/java/dev/architectury/event/forge/EventHandlerImplCommon.java
@@ -292,7 +292,7 @@ public class EventHandlerImplCommon {
     
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void event(ItemEntityPickupEvent.Post event) {
-        PlayerEvent.PICKUP_ITEM_POST.invoker().pickup(event.getPlayer(), event.getItemEntity(), event.getCurrentStack());
+        PlayerEvent.PICKUP_ITEM_POST.invoker().pickup(event.getPlayer(), event.getItemEntity(), event.getOriginalStack());
     }
     
     @SubscribeEvent(priority = EventPriority.HIGH)


### PR DESCRIPTION
`PICKUP_ITEM_POST` should fire with the original item stack, not the current one.
After player fully pick up the item stack, the remaining stack is empty, resulting in `minecraft:air`.
This NeoForge behavior is inconsistent with Forge / Fabric and thus I propose changing it to `getOriginalStack()`.

![41d82f5cab6606c0544cfdebfcf8501a](https://github.com/user-attachments/assets/27edbf29-84d8-4fa3-a6ba-97993c0b63fa)
