### PR TITLE
Fix fabric.mod.json versioning

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
   },
   "icon": "icon.png",
   "depends": {
-    "minecraft": "~1.21.6~",
+    "minecraft": "~1.21.6",
     "fabricloader": ">=0.15.4",
     "fabric-api": ">=0.127.0"
   },


### PR DESCRIPTION
Due to the incorrect Minecraft version description, the server fails to start.

```
Starting net.fabricmc.loader.impl.game.minecraft.BundlerClassPathCapture
[10:12:10] [main/INFO]: Loading Minecraft 1.21.6 with Fabric Loader 0.16.14
[10:12:10] [main/WARN]: Mod resolution failed
[10:12:10] [main/INFO]: Immediate reason: [HARD_DEP_INCOMPATIBLE_PRESELECTED architectury 17.0.4 {depends minecraft @ [~1.21.6~]}, ROOT_FORCELOAD_SINGLE architectury 17.0.4]
[10:12:10] [main/INFO]: Reason: [HARD_DEP architectury 17.0.4 {depends minecraft @ [~1.21.6~]}]
[10:12:10] [main/INFO]: SERVER environment disabled: [fabric-model-loading-api-v1, fabric-renderer-api-v1, fabric-sound-api-v1, fabric-screen-api-v1, fabric-key-binding-api-v1, fabric-rendering-v1, fabric-renderer-indigo]
[10:12:10] [main/INFO]: Fix: add [], remove [], replace [[architectury 17.0.4] -> add:architectury 1 ([(-鈭?鈭?])]

[10:12:10] [main/ERROR]: Incompatible mods found!
net.fabricmc.loader.impl.FormattedException: Some of your mods are incompatible with the game or each other!
A potential solution has been determined, this may resolve your problem:
         - Replace mod 'Architectury' (architectury) 17.0.4 with any version that is compatible with:
                 - minecraft 1.21.6
More details:
         - Mod 'Architectury' (architectury) 17.0.4 requires version 1.21.6~ of 'Minecraft' (minecraft), but only the wrong version is present: 1.21.6!
        at net.fabricmc.loader.impl.FormattedException.ofLocalized(FormattedException.java:51) ~[fabric-loader-0.16.14.jar:?]
        at net.fabricmc.loader.impl.FabricLoaderImpl.load(FabricLoaderImpl.java:196) ~[fabric-loader-0.16.14.jar:?]
        at net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:146) ~[fabric-loader-0.16.14.jar:?]
        at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:68) [fabric-loader-0.16.14.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.16.14.jar:?]
        at net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) [fabric-loader-0.16.14.jar:?]
```

So we fix the description so that it can start.