### PR TITLE
Fix RenderTypeRegistry.register parameters

### DIFF
--- a/common/src/main/java/dev/architectury/registry/client/rendering/RenderTypeRegistry.java
+++ b/common/src/main/java/dev/architectury/registry/client/rendering/RenderTypeRegistry.java
@@ -22,7 +22,7 @@ package dev.architectury.registry.client.rendering;
 import dev.architectury.injectables.annotations.ExpectPlatform;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.material.Fluid;
 
@@ -32,12 +32,12 @@ public final class RenderTypeRegistry {
     }
     
     @ExpectPlatform
-    public static void register(RenderType type, Block... blocks) {
+    public static void register(ChunkSectionLayer type, Block... blocks) {
         throw new AssertionError();
     }
     
     @ExpectPlatform
-    public static void register(RenderType type, Fluid... fluids) {
+    public static void register(ChunkSectionLayer type, Fluid... fluids) {
         throw new AssertionError();
     }
 }


### PR DESCRIPTION
Fixed an issue where the parameters of RenderTypeRegistry.register in common were not changed, which would cause the game to fail to start.
![Snipaste_2025-06-18_15-21-58](https://github.com/user-attachments/assets/24ff9c51-6cc5-4cd8-b856-0c4bb8a8a8c5)
