### PR TITLE
fix: change keyCode to action

### DIFF
--- a/common/src/main/java/dev/architectury/event/events/client/ClientRawInputEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/client/ClientRawInputEvent.java
@@ -32,7 +32,7 @@ public interface ClientRawInputEvent {
      */
     Event<MouseScrolled> MOUSE_SCROLLED = EventFactory.createEventResult();
     /**
-     * @see MouseClicked#mouseClicked(Minecraft, int, int, int)
+     * @see MouseClicked#mouseClicked(Minecraft, MouseButtonInfo, int)
      */
     Event<MouseClicked> MOUSE_CLICKED_PRE = EventFactory.createEventResult();
     Event<MouseClicked> MOUSE_CLICKED_POST = EventFactory.createEventResult();

--- a/common/src/main/java/dev/architectury/event/events/client/ClientRawInputEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/client/ClientRawInputEvent.java
@@ -47,12 +47,12 @@ public interface ClientRawInputEvent {
          * Equivalent to Forge's {@code InputEvent.KeyInputEvent} event.
          *
          * @param client   The Minecraft instance performing it.
-         * @param keyCode  The key code.
+         * @param action   The action that should be performed.
          * @param keyEvent The key event.
          * @return A {@link EventResult} determining the outcome of the event,
          * the execution of the vanilla pressing mechanism may be cancelled by the result.
          */
-        EventResult keyPressed(Minecraft client, int keyCode, KeyEvent keyEvent);
+        EventResult keyPressed(Minecraft client, int action, KeyEvent keyEvent);
     }
     
     interface MouseScrolled {

--- a/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinKeyboardHandler.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/client/MixinKeyboardHandler.java
@@ -73,9 +73,9 @@ public class MixinKeyboardHandler {
     }
     
     @Inject(method = "keyPress", at = @At("RETURN"), cancellable = true)
-    public void onRawKey(long handle, int key, KeyEvent keyEvent, CallbackInfo info) {
+    public void onRawKey(long handle, int action, KeyEvent keyEvent, CallbackInfo info) {
         if (handle == this.minecraft.getWindow().handle()) {
-            var result = ClientRawInputEvent.KEY_PRESSED.invoker().keyPressed(minecraft, key, keyEvent);
+            var result = ClientRawInputEvent.KEY_PRESSED.invoker().keyPressed(minecraft, action, keyEvent);
             if (result.isPresent())
                 info.cancel();
         }

--- a/neoforge/src/main/java/dev/architectury/event/forge/EventHandlerImplClient.java
+++ b/neoforge/src/main/java/dev/architectury/event/forge/EventHandlerImplClient.java
@@ -298,7 +298,7 @@ public class EventHandlerImplClient {
     
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void eventInputEvent(InputEvent.Key event) {
-        ClientRawInputEvent.KEY_PRESSED.invoker().keyPressed(Minecraft.getInstance(), event.getKey(), event.getKeyEvent());
+        ClientRawInputEvent.KEY_PRESSED.invoker().keyPressed(Minecraft.getInstance(), event.getAction(), event.getKeyEvent());
     }
     
     @SubscribeEvent(priority = EventPriority.HIGH)


### PR DESCRIPTION
The int passed to the keyPressed function represents the action instead of the keyCode. The keyCode is inside the keyEvent. The action is 1 for key pressed and 0 for key released.