### PR TITLE
fix: PlayerEvent.DROP_ITEM not working on Fabric 1.21.9

### DIFF
--- a/fabric/src/main/java/dev/architectury/mixin/fabric/MixinServerPlayer.java
+++ b/fabric/src/main/java/dev/architectury/mixin/fabric/MixinServerPlayer.java
@@ -25,6 +25,8 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.animal.horse.AbstractHorse;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -62,5 +64,12 @@ public class MixinServerPlayer {
     @Inject(method = "triggerDimensionChangeTriggers", at = @At("HEAD"))
     private void changeDimension(ServerLevel serverLevel, CallbackInfo ci) {
         PlayerEvent.CHANGE_DIMENSION.invoker().change((ServerPlayer) (Object) this, serverLevel.dimension(), ((ServerPlayer) (Object) this).level().dimension());
+    }
+    
+    @Inject(method = "drop(Lnet/minecraft/world/item/ItemStack;ZZ)Lnet/minecraft/world/entity/item/ItemEntity;", at = @At("RETURN"), cancellable = true)
+    private void dropItem(ItemStack itemStack, boolean bl, boolean bl2, CallbackInfoReturnable<ItemEntity> cir) {
+        if (cir.getReturnValue() != null && PlayerEvent.DROP_ITEM.invoker().drop((ServerPlayer) (Object) this, cir.getReturnValue()).isFalse()) {
+            cir.setReturnValue(null);
+        }
     }
 }


### PR DESCRIPTION
When the player drops an item using the 'Drop Selected Item' keybind, the `drop` method in the `ServerPlayer` class is used instead of the one in the `Player` class. The one in the `Player` class is used then the player drops the item when in an `AbstractContainerMenu`. 

This is also how NeoForge implemented their ItemTossEvent. https://github.com/neoforged/NeoForge/blob/464344df7906197d3e41c138065e33917bc9d68e/patches/net/minecraft/server/level/ServerPlayer.java.patch#L364