### PR TITLE
add FluidStackTemplate

### DIFF
--- a/common/src/main/java/dev/architectury/fluid/FluidStack.java
+++ b/common/src/main/java/dev/architectury/fluid/FluidStack.java
@@ -19,13 +19,15 @@
 
 package dev.architectury.fluid;
 
-import com.google.common.base.Suppliers;
 import com.mojang.serialization.Codec;
 import dev.architectury.hooks.fluid.FluidStackHooks;
 import dev.architectury.injectables.annotations.ExpectPlatform;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.component.*;
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;

--- a/common/src/main/java/dev/architectury/fluid/FluidStackTemplate.java
+++ b/common/src/main/java/dev/architectury/fluid/FluidStackTemplate.java
@@ -1,0 +1,201 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.fluid;
+
+import com.mojang.serialization.Codec;
+import dev.architectury.hooks.fluid.FluidStackTemplateHooks;
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.level.material.Fluid;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class FluidStackTemplate implements DataComponentHolder {
+    private static final FluidStackTemplateAdapter<Object, Object> ADAPTER = adapt(FluidStackTemplate::getValue, FluidStackTemplate::new);
+    public static final Codec<FluidStackTemplate> CODEC = ADAPTER.codec();
+    public static final StreamCodec<RegistryFriendlyByteBuf, FluidStackTemplate> STREAM_CODEC = ADAPTER.streamCodec();
+    
+    private final Object value;
+    
+    private FluidStackTemplate(Supplier<Fluid> fluid, long amount, DataComponentPatch patch) {
+        this(ADAPTER.of(fluid, amount, patch));
+    }
+    
+    private FluidStackTemplate(Object value) {
+        this.value = Objects.requireNonNull(value);
+    }
+    
+    private Object getValue() {
+        return value;
+    }
+    
+    @ExpectPlatform
+    private static FluidStackTemplateAdapter<Object, Object> adapt(Function<FluidStackTemplate, Object> toValue, Function<Object, FluidStackTemplate> fromValue) {
+        throw new AssertionError();
+    }
+    
+    @ApiStatus.Internal
+    public interface FluidStackTemplateAdapter<T, R> {
+        T of(Supplier<Fluid> fluid, long amount, @Nullable DataComponentPatch patch);
+        
+        Holder<Fluid> fluid(T object);
+        
+        long amount(T object);
+        
+        T withAmount(T object, int amount);
+        
+        DataComponentMap components(T value);
+        
+        DataComponentPatch patch(T value);
+        
+        R apply(T value, DataComponentPatch patch);
+        
+        R apply(T value, int amount, DataComponentPatch patch);
+        
+        @Nullable <D> D get(T value, DataComponentType<D> type);
+        
+        @Nullable <D> D get(T value, Supplier<DataComponentType<D>> type);
+        
+        T copy(T value);
+        
+        int hashCode(T value);
+        
+        Codec<FluidStackTemplate> codec();
+        
+        StreamCodec<RegistryFriendlyByteBuf, FluidStackTemplate> streamCodec();
+    }
+    
+    public static Object of(FluidStackTemplate stack) {
+        return new FluidStackTemplate(stack);
+    }
+    
+    public static FluidStackTemplate of(Holder<Fluid> fluid, long amount) {
+        return new FluidStackTemplate(fluid::value, amount, DataComponentPatch.EMPTY);
+    }
+    
+    public static FluidStackTemplate of(Holder<Fluid> fluid, long amount, DataComponentPatch patch) {
+        return new FluidStackTemplate(fluid::value, amount, patch);
+    }
+    
+    public FluidStack create() {
+        return FluidStack.create(fluid().value(), amount(), getPatch());
+    }
+    
+    public Holder<Fluid> fluid() {
+        return ADAPTER.fluid(value);
+    }
+    
+    
+    public long amount() {
+        return ADAPTER.amount(value);
+    }
+    
+    
+    @Override
+    public DataComponentMap getComponents() {
+        return ADAPTER.components(value);
+    }
+    
+    public DataComponentPatch getPatch() {
+        return ADAPTER.patch(value);
+    }
+    
+    public void apply(DataComponentPatch patch) {
+        ADAPTER.apply(value, patch);
+    }
+    
+    public void apply(int amount, DataComponentPatch patch) {
+        ADAPTER.apply(value,amount, patch);
+    }
+    
+    public String getTranslationKey() {
+        return FluidStackTemplateHooks.getTranslationKey(this);
+    }
+    
+    public FluidStackTemplate copy() {
+        return new FluidStackTemplate(ADAPTER.copy(value));
+    }
+    
+    @Override
+    public int hashCode() {
+        return ADAPTER.hashCode(value);
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof FluidStackTemplate)) {
+            return false;
+        }
+        return isFluidStackEqual((FluidStackTemplate) o);
+    }
+    
+    public boolean isFluidStackEqual(FluidStackTemplate other) {
+        return fluid() == other.fluid() && amount() == other.amount() && isComponentEqual(other);
+    }
+    
+    public boolean isFluidEqual(FluidStackTemplate other) {
+        return fluid() == other.fluid();
+    }
+    
+    public boolean isComponentEqual(FluidStackTemplate other) {
+        var patch = getComponents();
+        var otherPatch = other.getComponents();
+        return Objects.equals(patch, otherPatch);
+    }
+    
+    public static FluidStackTemplate read(RegistryFriendlyByteBuf buf) {
+        return FluidStackTemplateHooks.read(buf);
+    }
+    
+    public static Optional<FluidStackTemplate> read(HolderLookup.Provider provider, Tag tag) {
+        return FluidStackTemplateHooks.read(provider, tag);
+    }
+    
+    public void write(RegistryFriendlyByteBuf buf) {
+        FluidStackTemplateHooks.write(this, buf);
+    }
+    
+    public Tag write(HolderLookup.Provider provider, Tag tag) {
+        return FluidStackTemplateHooks.write(provider, this, tag);
+    }
+    
+    public FluidStackTemplate copyWithAmount(long amount) {
+        return new FluidStackTemplate(() -> fluid().value(), amount, getPatch());
+    }
+    
+    @ApiStatus.Internal
+    public static void init() {
+        // classloading my beloved 😍
+        // please don't use this by the way
+    }
+}

--- a/common/src/main/java/dev/architectury/hooks/fluid/FluidStackTemplateHooks.java
+++ b/common/src/main/java/dev/architectury/hooks/fluid/FluidStackTemplateHooks.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.hooks.fluid;
+
+import dev.architectury.fluid.FluidStack;
+import dev.architectury.fluid.FluidStackTemplate;
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluid;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class FluidStackTemplateHooks {
+    private FluidStackTemplateHooks() {
+    }
+    
+    @ExpectPlatform
+    public static Component getName(FluidStackTemplate stack) {
+        throw new AssertionError();
+    }
+    
+    @ExpectPlatform
+    public static String getTranslationKey(FluidStackTemplate stack) {
+        throw new AssertionError();
+    }
+    
+    /**
+     * Platform-specific FluidStack read.
+     */
+    @ExpectPlatform
+    public static FluidStackTemplate read(RegistryFriendlyByteBuf buf) {
+        throw new AssertionError();
+    }
+    
+    /**
+     * Platform-specific FluidStack write.
+     */
+    @ExpectPlatform
+    public static void write(FluidStackTemplate stack, RegistryFriendlyByteBuf buf) {
+        throw new AssertionError();
+    }
+    
+    /**
+     * Platform-specific FluidStack read.
+     */
+    @ExpectPlatform
+    public static Optional<FluidStackTemplate> read(HolderLookup.Provider provider, Tag tag) {
+        throw new AssertionError();
+    }
+    
+    /**
+     * Platform-specific FluidStack write.
+     */
+    @ExpectPlatform
+    public static Tag write(HolderLookup.Provider provider, FluidStackTemplate stack, Tag tag) {
+        throw new AssertionError();
+    }
+}

--- a/fabric/src/main/java/dev/architectury/fluid/fabric/FluidStackTemplateImpl.java
+++ b/fabric/src/main/java/dev/architectury/fluid/fabric/FluidStackTemplateImpl.java
@@ -23,8 +23,10 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.architectury.fluid.FluidStack;
+import dev.architectury.fluid.FluidStackTemplate;
 import io.netty.buffer.ByteBuf;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
@@ -41,32 +43,30 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 @ApiStatus.Internal
-public enum FluidStackImpl implements FluidStack.FluidStackAdapter<FluidStackImpl.Pair> {
+public enum FluidStackTemplateImpl implements FluidStackTemplate.FluidStackTemplateAdapter<FluidStackTemplateImpl.Pair, FluidStackImpl.Pair> {
     INSTANCE;
     
     static {
-        dev.architectury.fluid.FluidStack.init();
+        FluidStack.init();
     }
     
-    public static Function<FluidStack, Object> toValue;
-    public static Function<Object, FluidStack> fromValue;
+    public static Function<FluidStackTemplate, Object> toValue;
+    public static Function<Object, FluidStackTemplate> fromValue;
     
-    public static FluidStack.FluidStackAdapter<Object> adapt(Function<FluidStack, Object> toValue, Function<Object, dev.architectury.fluid.FluidStack> fromValue) {
-        FluidStackImpl.toValue = toValue;
-        FluidStackImpl.fromValue = fromValue;
-        return (FluidStack.FluidStackAdapter<Object>) (FluidStack.FluidStackAdapter<?>) INSTANCE;
+    public static FluidStackTemplate.FluidStackTemplateAdapter<Object, Object> adapt(Function<FluidStackTemplate, Object> toValue, Function<Object, FluidStackTemplate> fromValue) {
+        FluidStackTemplateImpl.toValue = toValue;
+        FluidStackTemplateImpl.fromValue = fromValue;
+        return (FluidStackTemplate.FluidStackTemplateAdapter<Object, Object>) (FluidStackTemplate.FluidStackTemplateAdapter<?, ?>) INSTANCE;
     }
     
     public static class Pair {
-        public Fluid fluid;
-        public PatchedDataComponentMap components;
-        public long amount;
+        public final Fluid fluid;
+        public final PatchedDataComponentMap components;
+        public final long amount;
         
         public Pair(Fluid fluid, @Nullable DataComponentPatch patch, long amount) {
             this(fluid,
@@ -91,7 +91,7 @@ public enum FluidStackImpl implements FluidStack.FluidStackAdapter<FluidStackImp
     }
     
     @Override
-    public FluidStackImpl.Pair create(Supplier<Fluid> fluid, long amount, @Nullable DataComponentPatch patch) {
+    public Pair of(Supplier<Fluid> fluid, long amount, @Nullable DataComponentPatch patch) {
         Fluid fluidType = Objects.requireNonNull(fluid).get();
         if (fluidType instanceof FlowingFluid flowingFluid) {
             fluidType = flowingFluid.getSource();
@@ -100,75 +100,61 @@ public enum FluidStackImpl implements FluidStack.FluidStackAdapter<FluidStackImp
     }
     
     @Override
-    public Supplier<Fluid> getRawFluidSupplier(FluidStackImpl.Pair object) {
-        return () -> object.fluid;
+    public Holder<Fluid> fluid(Pair object) {
+        return object.fluid.builtInRegistryHolder();
     }
     
     @Override
-    public Fluid getFluid(FluidStackImpl.Pair object) {
-        return object.fluid;
-    }
-    
-    @Override
-    public long getAmount(FluidStackImpl.Pair object) {
+    public long amount(Pair object) {
         return object.amount;
     }
     
     @Override
-    public void setAmount(FluidStackImpl.Pair object, long amount) {
-        object.amount = amount;
-    }
-    
-    public DataComponentPatch getPatch(FluidStackImpl.Pair value) {
-        return value.getPatch();
+    public Pair withAmount(Pair object, int amount) {
+        return new Pair(object.fluid, object.components, amount);
     }
     
     @Override
-    public PatchedDataComponentMap getComponents(Pair value) {
+    public DataComponentMap components(Pair value) {
         return value.components;
     }
     
     @Override
-    public void applyComponents(Pair value, DataComponentPatch patch) {
-        value.components.applyPatch(patch);
+    public DataComponentPatch patch(Pair value) {
+        return value.components.asPatch();
     }
     
     @Override
-    public void applyComponents(Pair value, DataComponentMap patch) {
-        value.components.setAll(patch);
+    public FluidStackImpl.Pair apply(Pair value, DataComponentPatch patch) {
+        FluidStackImpl.Pair newPair =  new FluidStackImpl.Pair(value.fluid, value.components, value.amount);
+        newPair.components.applyPatch(patch);
+        return newPair;
     }
     
     @Override
-    @Nullable
-    public <D> D set(Pair value, DataComponentType<D> type, @Nullable D component) {
-        return value.components.set(type, component);
+    public FluidStackImpl.Pair apply(Pair value, int amount, DataComponentPatch patch) {
+        FluidStackImpl.Pair newPair =  new FluidStackImpl.Pair(value.fluid, value.components, amount);
+        newPair.components.applyPatch(patch);
+        return newPair;
     }
     
     @Override
-    @Nullable
-    public <D> D remove(Pair value, DataComponentType<? extends D> type) {
-        return value.components.remove(type);
+    public @org.jspecify.annotations.Nullable <D> D get(Pair value, DataComponentType<D> type) {
+        return value.components.get(type);
     }
     
     @Override
-    @Nullable
-    public <D> D update(Pair value, DataComponentType<D> type, D component, UnaryOperator<D> updater) {
-        return value.components.set(type, updater.apply(getComponents(value).getOrDefault(type, component)));
+    public @org.jspecify.annotations.Nullable <D> D get(Pair value, Supplier<DataComponentType<D>> type) {
+        return value.components.get(type.get());
     }
     
     @Override
-    @Nullable
-    public <D, U> D update(Pair value, DataComponentType<D> type, D component, U updateContext, BiFunction<D, U, D> updater) {
-        return value.components.set(type, updater.apply(getComponents(value).getOrDefault(type, component), updateContext));
-    }
-    
-    @Override
-    public FluidStackImpl.Pair copy(FluidStackImpl.Pair value) {
+    public Pair copy(FluidStackTemplateImpl.Pair value) {
         return new Pair(value.fluid, value.components.copy(), value.amount);
     }
     
     @Override
-    public int hashCode(FluidStackImpl.Pair value) {
+    public int hashCode(FluidStackTemplateImpl.Pair value) {
         int code = 1;
         code = 31 * code + value.fluid.hashCode();
         code = 31 * code + Long.hashCode(value.amount);
@@ -177,21 +163,21 @@ public enum FluidStackImpl implements FluidStack.FluidStackAdapter<FluidStackImp
     }
     
     @Override
-    public Codec<FluidStack> codec() {
+    public Codec<FluidStackTemplate> codec() {
         return RecordCodecBuilder.create(instance -> instance.group(
-                BuiltInRegistries.FLUID.holderByNameCodec().fieldOf("fluid").forGetter(stack -> stack.getFluid().builtInRegistryHolder()),
+                BuiltInRegistries.FLUID.holderByNameCodec().fieldOf("fluid").forGetter(FluidStackTemplate::fluid),
                 Codec.LONG.validate(value -> value.compareTo(0L) >= 0 && value.compareTo(Long.MAX_VALUE) <= 0
                         ? DataResult.success(value)
-                        : DataResult.error(() -> "Value must be non-negative: " + value)).fieldOf("amount").forGetter(FluidStack::getAmount),
-                DataComponentPatch.CODEC.optionalFieldOf("components", DataComponentPatch.EMPTY).forGetter(FluidStack::getPatch)
-        ).apply(instance, FluidStack::create));
+                        : DataResult.error(() -> "Value must be non-negative: " + value)).fieldOf("amount").forGetter(FluidStackTemplate::amount),
+                DataComponentPatch.CODEC.optionalFieldOf("components", DataComponentPatch.EMPTY).forGetter(FluidStackTemplate::getPatch)
+        ).apply(instance, FluidStackTemplate::of));
     }
     
     @Override
-    public StreamCodec<RegistryFriendlyByteBuf, FluidStack> streamCodec() {
-        return StreamCodec.composite(ByteBufCodecs.holderRegistry(Registries.FLUID), stack -> stack.getFluid().builtInRegistryHolder(),
-                StreamCodec.of(ByteBuf::writeLong, ByteBuf::readLong), FluidStack::getAmount,
-                DataComponentPatch.STREAM_CODEC, FluidStack::getPatch,
-                FluidStack::create);
+    public StreamCodec<RegistryFriendlyByteBuf, FluidStackTemplate> streamCodec() {
+        return StreamCodec.composite(ByteBufCodecs.holderRegistry(Registries.FLUID), FluidStackTemplate::fluid,
+                StreamCodec.of(ByteBuf::writeLong, ByteBuf::readLong), FluidStackTemplate::amount,
+                DataComponentPatch.STREAM_CODEC, FluidStackTemplate::getPatch,
+                FluidStackTemplate::of);
     }
 }

--- a/fabric/src/main/java/dev/architectury/hooks/fluid/fabric/FluidStackTemplateHooksFabric.java
+++ b/fabric/src/main/java/dev/architectury/hooks/fluid/fabric/FluidStackTemplateHooksFabric.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.hooks.fluid.fabric;
+
+import dev.architectury.fluid.FluidStack;
+import dev.architectury.fluid.FluidStackTemplate;
+import dev.architectury.fluid.fabric.FluidStackImpl;
+import dev.architectury.fluid.fabric.FluidStackTemplateImpl;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
+import net.minecraft.core.component.PatchedDataComponentMap;
+
+public final class FluidStackTemplateHooksFabric {
+    private FluidStackTemplateHooksFabric() {
+    }
+    
+    public static FluidStackTemplate fromFabric(StorageView<FluidVariant> storageView) {
+        return fromFabric(storageView.getResource(), storageView.getAmount());
+    }
+
+    public static FluidStackTemplate fromFabric(FluidVariant variant, long amount) {
+        return FluidStackTemplateImpl.fromValue.apply(new FluidStackTemplateImpl.Pair(variant.getFluid(), new PatchedDataComponentMap(variant.getComponents()), amount));
+    }
+
+    public static FluidVariant toFabric(FluidStackTemplate stack) {
+        return ((FluidStackTemplateImpl.Pair) FluidStackTemplateImpl.toValue.apply(stack)).toVariant();
+    }
+}

--- a/fabric/src/main/java/dev/architectury/hooks/fluid/fabric/FluidStackTemplateHooksImpl.java
+++ b/fabric/src/main/java/dev/architectury/hooks/fluid/fabric/FluidStackTemplateHooksImpl.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.hooks.fluid.fabric;
+
+import com.mojang.logging.LogUtils;
+import dev.architectury.fluid.FluidStackTemplate;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+public class FluidStackTemplateHooksImpl {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
+    public static Component getName(FluidStackTemplate stack) {
+        return FluidVariantAttributes.getName(FluidStackTemplateHooksFabric.toFabric(stack));
+    }
+    
+    public static String getTranslationKey(FluidStackTemplate stack) {
+        return stack.getTranslationKey();
+    }
+    
+    public static FluidStackTemplate read(RegistryFriendlyByteBuf buf) {
+        return FluidStackTemplate.STREAM_CODEC.decode(buf);
+    }
+    
+    public static void write(FluidStackTemplate stack, RegistryFriendlyByteBuf buf) {
+        FluidStackTemplate.STREAM_CODEC.encode(buf, stack);
+    }
+    
+    public static Optional<FluidStackTemplate> read(HolderLookup.Provider provider, Tag tag) {
+        return FluidStackTemplate.CODEC.parse(provider.createSerializationContext(NbtOps.INSTANCE), tag)
+                .resultOrPartial(string -> LOGGER.error("Tried to load invalid fluid stack: '{}'", string));
+    }
+    
+    public static Tag write(HolderLookup.Provider provider, FluidStackTemplate stack, Tag tag) {
+        return FluidStackTemplate.CODEC.encode(stack, provider.createSerializationContext(NbtOps.INSTANCE), tag).getOrThrow(IllegalStateException::new);
+    }
+}

--- a/neoforge/src/main/java/dev/architectury/fluid/forge/FluidStackImpl.java
+++ b/neoforge/src/main/java/dev/architectury/fluid/forge/FluidStackImpl.java
@@ -145,7 +145,7 @@ public enum FluidStackImpl implements dev.architectury.fluid.FluidStack.FluidSta
     
     @Override
     public int hashCode(FluidStack value) {
-        var code = 1;
+        int code = 1;
         code = 31 * code + value.getFluid().hashCode();
         code = 31 * code + value.getAmount();
         code = 31 * code + value.getComponents().hashCode();

--- a/neoforge/src/main/java/dev/architectury/fluid/forge/FluidStackTemplateImpl.java
+++ b/neoforge/src/main/java/dev/architectury/fluid/forge/FluidStackTemplateImpl.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.fluid.forge;
+
+import com.mojang.serialization.Codec;
+import dev.architectury.hooks.fluid.forge.FluidStackTemplateHooksForge;
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.FluidStackTemplate;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static dev.architectury.utils.Amount.toInt;
+
+@ApiStatus.Internal
+public enum FluidStackTemplateImpl implements dev.architectury.fluid.FluidStackTemplate.FluidStackTemplateAdapter<FluidStackTemplate, FluidStack> {
+    INSTANCE;
+    
+    static {
+        dev.architectury.fluid.FluidStackTemplate.init();
+    }
+    
+    public static Function<dev.architectury.fluid.FluidStackTemplate, Object> toValue;
+    public static Function<Object, dev.architectury.fluid.FluidStackTemplate> fromValue;
+    
+    public static dev.architectury.fluid.FluidStackTemplate.FluidStackTemplateAdapter<Object, Object> adapt(Function<dev.architectury.fluid.FluidStackTemplate, Object> toValue, Function<Object, dev.architectury.fluid.FluidStackTemplate> fromValue) {
+        FluidStackTemplateImpl.toValue = toValue;
+        FluidStackTemplateImpl.fromValue = fromValue;
+        return (dev.architectury.fluid.FluidStackTemplate.FluidStackTemplateAdapter<Object, Object>) (dev.architectury.fluid.FluidStackTemplate.FluidStackTemplateAdapter<?, ?>) INSTANCE;
+    }
+    
+    @Override
+    public FluidStackTemplate of(Supplier<Fluid> fluid, long amount, @Nullable DataComponentPatch patch) {
+        Fluid fluidType = Objects.requireNonNull(fluid).get();
+        
+        if (fluidType.equals(Fluids.EMPTY)) {
+            throw new IllegalArgumentException("Fluid is empty");
+        }
+        
+        if (patch == null) {
+            return new FluidStackTemplate(fluidType, toInt(amount));
+        } else {
+            return new FluidStackTemplate(fluidType, toInt(amount), patch);
+        }
+    }
+    
+    @Override
+    public Holder<Fluid> fluid(FluidStackTemplate object) {
+        return object.fluid();
+    }
+    
+    @Override
+    public long amount(FluidStackTemplate object) {
+        return object.amount();
+    }
+    
+    @Override
+    public FluidStackTemplate withAmount(FluidStackTemplate object, int amount) {
+        return object.withAmount(amount);
+    }
+    
+    @Override
+    public DataComponentMap components(FluidStackTemplate value) {
+        return DataComponentMap.EMPTY;
+    }
+    
+    @Override
+    public DataComponentPatch patch(FluidStackTemplate value) {
+        return value.components();
+    }
+    
+    @Override
+    public FluidStack apply(FluidStackTemplate value, DataComponentPatch patch) {
+        return value.apply(patch);
+    }
+    
+    @Override
+    public FluidStack apply(FluidStackTemplate value, int amount, DataComponentPatch patch) {
+        return value.apply(amount, patch);
+    }
+    
+    @Override
+    @Nullable
+    public <D> D get(FluidStackTemplate value, DataComponentType<D> type) {
+        return value.get(type);
+    }
+    
+    @Override
+    @Nullable
+    public <D> D get(FluidStackTemplate value, Supplier<DataComponentType<D>> type) {
+        return value.get(type);
+    }
+    
+    @Override
+    public FluidStackTemplate copy(FluidStackTemplate value) {
+        return new FluidStackTemplate(value.fluid(), value.amount(), value.components());
+    }
+    
+    @Override
+    public int hashCode(FluidStackTemplate value) {
+        int code = 1;
+        code = 31 * code + value.fluid().hashCode();
+        code = 31 * code + value.amount();
+        code = 31 * code + value.components().hashCode();
+        return code;
+    }
+    
+    @Override
+    public Codec<dev.architectury.fluid.FluidStackTemplate> codec() {
+        return FluidStackTemplate.CODEC.xmap(FluidStackTemplateHooksForge::fromForge, FluidStackTemplateHooksForge::toForge);
+    }
+    
+    @Override
+    public StreamCodec<RegistryFriendlyByteBuf, dev.architectury.fluid.FluidStackTemplate> streamCodec() {
+        return FluidStackTemplate.STREAM_CODEC.map(FluidStackTemplateHooksForge::fromForge, FluidStackTemplateHooksForge::toForge);
+    }
+}

--- a/neoforge/src/main/java/dev/architectury/hooks/fluid/forge/FluidStackTemplateHooksForge.java
+++ b/neoforge/src/main/java/dev/architectury/hooks/fluid/forge/FluidStackTemplateHooksForge.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.hooks.fluid.forge;
+
+import dev.architectury.fluid.FluidStackTemplate;
+import dev.architectury.fluid.forge.FluidStackTemplateImpl;
+
+public final class FluidStackTemplateHooksForge {
+    private FluidStackTemplateHooksForge() {
+    }
+    
+    public static FluidStackTemplate fromForge(net.neoforged.neoforge.fluids.FluidStackTemplate stack) {
+        return FluidStackTemplateImpl.fromValue.apply(stack);
+    }
+    
+    public static net.neoforged.neoforge.fluids.FluidStackTemplate toForge(FluidStackTemplate stack) {
+        return (net.neoforged.neoforge.fluids.FluidStackTemplate) FluidStackTemplateImpl.toValue.apply(stack);
+    }
+}

--- a/neoforge/src/main/java/dev/architectury/hooks/fluid/forge/FluidStackTemplateHooksImpl.java
+++ b/neoforge/src/main/java/dev/architectury/hooks/fluid/forge/FluidStackTemplateHooksImpl.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of architectury.
+ * Copyright (C) 2020, 2021, 2022 architectury
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package dev.architectury.hooks.fluid.forge;
+
+import com.mojang.logging.LogUtils;
+import dev.architectury.fluid.FluidStack;
+import dev.architectury.fluid.FluidStackTemplate;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluid;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+public class FluidStackTemplateHooksImpl {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
+    public static Component getName(FluidStackTemplate stack) {
+        return stack.fluid().value().getFluidType().getDescription(FluidStackTemplateHooksForge.toForge(stack).create());
+    }
+    
+    public static String getTranslationKey(FluidStackTemplate stack) {
+        return stack.fluid().value().getFluidType().getDescriptionId(FluidStackTemplateHooksForge.toForge(stack).create());
+    }
+    
+    public static FluidStackTemplate read(RegistryFriendlyByteBuf buf) {
+        return FluidStackTemplate.STREAM_CODEC.decode(buf);
+    }
+    
+    public static void write(FluidStackTemplate stack, RegistryFriendlyByteBuf buf) {
+        FluidStackTemplate.STREAM_CODEC.encode(buf, stack);
+    }
+    
+    public static Optional<FluidStackTemplate> read(HolderLookup.Provider provider, Tag tag) {
+        return FluidStackTemplate.CODEC.parse(provider.createSerializationContext(NbtOps.INSTANCE), tag)
+                .resultOrPartial(string -> LOGGER.error("Tried to load invalid fluid stack: '{}'", string));
+    }
+    
+    public static Tag write(HolderLookup.Provider provider, FluidStackTemplate stack, Tag tag) {
+        return FluidStackTemplate.CODEC.encode(stack, provider.createSerializationContext(NbtOps.INSTANCE), tag).getOrThrow(IllegalStateException::new);
+    }
+}


### PR DESCRIPTION
Add cross-platform FluidStackTemplate support

This is needed because NeoForge introduced `FluidStackTemplate` in 26.1, an immutable representation of a `FluidStack` that can be safely referenced before registries are loaded.

This PR introduces a custom `FluidStackTemplate` implementation that works on both NeoForge and Fabric.

`FluidStackTemplate` should be used for everything that needs to be accessed or loaded before the registries are available.