### PR TITLE
Add registries as additional parameter to loot table modification event

### DIFF
--- a/common/src/main/java/dev/architectury/event/events/common/LootEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/common/LootEvent.java
@@ -21,6 +21,7 @@ package dev.architectury.event.events.common;
 
 import dev.architectury.event.Event;
 import dev.architectury.event.EventFactory;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.LootTable;
@@ -48,7 +49,7 @@ public interface LootEvent {
      * <pre>{@code
      * LootEvent.MODIFY_LOOT_TABLE.register((key, context, builtin) -> {
      *     // Check that the loot table is dirt and built-in
-     *     if (builtin && Blocks.DIRT.getLootTable().equals(key)) {
+     *     if (builtin && Blocks.DIRT.getLootTable().equals(Optional.ofNullable(key))) {
      *         // Create a loot pool with a single item entry of Items.DIAMOND
      *         LootPool.Builder pool = LootPool.lootPool().add(LootItem.lootTableItem(Items.DIAMOND));
      *         context.addPool(pool);
@@ -56,7 +57,7 @@ public interface LootEvent {
      * });
      * }</pre>
      *
-     * @see ModifyLootTable#modifyLootTable(ResourceKey, LootTableModificationContext, boolean)
+     * @see ModifyLootTable#modifyLootTable
      */
     Event<ModifyLootTable> MODIFY_LOOT_TABLE = EventFactory.createLoop();
     
@@ -65,12 +66,13 @@ public interface LootEvent {
         /**
          * Modifies a loot table.
          *
-         * @param key     the loot table key
-         * @param context the context used to modify the loot table
-         * @param builtin if {@code true}, the loot table is built-in;
-         *                if {@code false}, it is from a user data pack
+         * @param registries the registries provider
+         * @param key        the loot table key
+         * @param context    the context used to modify the loot table
+         * @param builtin    if {@code true}, the loot table is built-in;
+         *                   if {@code false}, it is from a user data pack
          */
-        void modifyLootTable(ResourceKey<LootTable> key, LootTableModificationContext context, boolean builtin);
+        void modifyLootTable(HolderLookup.Provider registries, ResourceKey<LootTable> key, LootTableModificationContext context, boolean builtin);
     }
     
     /**

--- a/common/src/main/java/dev/architectury/event/events/common/LootEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/common/LootEvent.java
@@ -57,7 +57,7 @@ public interface LootEvent {
      * });
      * }</pre>
      *
-     * @see ModifyLootTable#modifyLootTable
+     * @see ModifyLootTable#modifyLootTable(HolderLookup.Provider, ResourceKey, LootTableModificationContext, boolean)
      */
     Event<ModifyLootTable> MODIFY_LOOT_TABLE = EventFactory.createLoop();
     

--- a/common/src/main/java/dev/architectury/event/events/common/LootEvent.java
+++ b/common/src/main/java/dev/architectury/event/events/common/LootEvent.java
@@ -47,7 +47,7 @@ public interface LootEvent {
      *
      * <h2>Example: adding diamonds as a drop for dirt</h2>
      * <pre>{@code
-     * LootEvent.MODIFY_LOOT_TABLE.register((key, context, builtin) -> {
+     * LootEvent.MODIFY_LOOT_TABLE.register((registries, key, context, builtin) -> {
      *     // Check that the loot table is dirt and built-in
      *     if (builtin && Blocks.DIRT.getLootTable().equals(Optional.ofNullable(key))) {
      *         // Create a loot pool with a single item entry of Items.DIAMOND
@@ -66,13 +66,28 @@ public interface LootEvent {
         /**
          * Modifies a loot table.
          *
+         * @param key     the loot table key
+         * @param context the context used to modify the loot table
+         * @param builtin if {@code true}, the loot table is built-in;
+         *                if {@code false}, it is from a user data pack
+         * @deprecated Use
+         * {@link #modifyLootTable(HolderLookup.Provider, ResourceKey, LootTableModificationContext, boolean)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        void modifyLootTable(ResourceKey<LootTable> key, LootTableModificationContext context, boolean builtin);
+
+        /**
+         * Modifies a loot table.
+         *
          * @param registries the registries provider
          * @param key        the loot table key
          * @param context    the context used to modify the loot table
          * @param builtin    if {@code true}, the loot table is built-in;
          *                   if {@code false}, it is from a user data pack
          */
-        void modifyLootTable(HolderLookup.Provider registries, ResourceKey<LootTable> key, LootTableModificationContext context, boolean builtin);
+        default void modifyLootTable(HolderLookup.Provider registries, ResourceKey<LootTable> key, LootTableModificationContext context, boolean builtin) {
+            modifyLootTable(key, context, builtin);
+        }
     }
     
     /**

--- a/fabric/src/main/java/dev/architectury/event/fabric/EventHandlerImpl.java
+++ b/fabric/src/main/java/dev/architectury/event/fabric/EventHandlerImpl.java
@@ -92,7 +92,7 @@ public class EventHandlerImpl {
         AttackBlockCallback.EVENT.register((player, world, hand, pos, face) -> InteractionEvent.LEFT_CLICK_BLOCK.invoker().click(player, hand, pos, face).asMinecraft());
         AttackEntityCallback.EVENT.register((player, world, hand, entity, hitResult) -> PlayerEvent.ATTACK_ENTITY.invoker().attack(player, world, entity, hand, hitResult).asMinecraft());
         
-        LootTableEvents.MODIFY.register((key, tableBuilder, source, provider) -> LootEvent.MODIFY_LOOT_TABLE.invoker().modifyLootTable(key, new LootTableModificationContextImpl(tableBuilder), source.isBuiltin()));
+        LootTableEvents.MODIFY.register((key, tableBuilder, source, provider) -> LootEvent.MODIFY_LOOT_TABLE.invoker().modifyLootTable(provider, key, new LootTableModificationContextImpl(tableBuilder), source.isBuiltin()));
         
         ServerMessageDecoratorEvent.EVENT.register(ServerMessageDecoratorEvent.CONTENT_PHASE, (player, component) -> {
             ChatEvent.ChatComponent chatComponent = new ChatComponentImpl(component);

--- a/neoforge/src/main/java/dev/architectury/event/neoforge/EventHandlerImplCommon.java
+++ b/neoforge/src/main/java/dev/architectury/event/neoforge/EventHandlerImplCommon.java
@@ -409,7 +409,7 @@ public class EventHandlerImplCommon {
     
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void event(LootTableLoadEvent event) {
-        LootEvent.MODIFY_LOOT_TABLE.invoker().modifyLootTable(ResourceKey.create(Registries.LOOT_TABLE, event.getName()), new LootTableModificationContextImpl(event.getTable()), true);
+        LootEvent.MODIFY_LOOT_TABLE.invoker().modifyLootTable(event.getRegistries(), ResourceKey.create(Registries.LOOT_TABLE, event.getName()), new LootTableModificationContextImpl(event.getTable()), true);
     }
     
     @SubscribeEvent(priority = EventPriority.HIGH)

--- a/testmod-common/src/main/java/dev/architectury/test/loot/TestLoot.java
+++ b/testmod-common/src/main/java/dev/architectury/test/loot/TestLoot.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 
 public class TestLoot {
     public static void init() {
-        LootEvent.MODIFY_LOOT_TABLE.register((key, context, builtin) -> {
+        LootEvent.MODIFY_LOOT_TABLE.register((provider, key, context, builtin) -> {
             // Check that the loot table is dirt and built-in
             if (builtin && Blocks.DIRT.getLootTable().equals(Optional.ofNullable(key))) {
                 // Create a loot pool with a single item entry of Items.DIAMOND

--- a/testmod-common/src/main/java/dev/architectury/test/loot/TestLoot.java
+++ b/testmod-common/src/main/java/dev/architectury/test/loot/TestLoot.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 
 public class TestLoot {
     public static void init() {
-        LootEvent.MODIFY_LOOT_TABLE.register((provider, key, context, builtin) -> {
+        LootEvent.MODIFY_LOOT_TABLE.register((key, context, builtin) -> {
             // Check that the loot table is dirt and built-in
             if (builtin && Blocks.DIRT.getLootTable().equals(Optional.ofNullable(key))) {
                 // Create a loot pool with a single item entry of Items.DIAMOND


### PR DESCRIPTION
Alas, this would be a breaking change and additionally it would also affect *every* version of Architectury API since 1.21.
The extra object is important when functions such as `EnchantRandomlyFunction#randomApplicableEnchantment` are to be used.