### PR TITLE
Fix BiomeModifications failing on NeoForge

### DIFF
--- a/neoforge/src/main/resources/data/architectury/neoforge/biome_modifier/impl.json
+++ b/neoforge/src/main/resources/data/architectury/neoforge/biome_modifier/impl.json
@@ -1,0 +1,3 @@
+{
+    "type" : "architectury:none_biome_mod_codec"
+}


### PR DESCRIPTION
Added the missing `impl.json` biome modifier data file to the datapack of the `neoforge` module.

Because this file was missing, all programmatic biome modifications via `BiomeModifications#addProperties` were silently ignored on NeoForge. I basically just copied it over from the `forge` module which needed the same file for data-driven biome modifications to work. It seems copying the file over was simply overlooked :)

I've confirmed biome modifications to be working in the NeoForge test mod after adding this file. Before this change, the passed BiConsumer was never invoked.

All the NeoForge modules have this problem up to and including the most recent version--if that's welcome, I can open PRs for the other branches as well :)