### PR TITLE
Fix pipeline by updating deprecated runner

### DIFF
--- a/.github/workflows/1.21_pr.yml
+++ b/.github/workflows/1.21_pr.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   validate-gradle:
     name: "Validate Gradle wrapper"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,7 +21,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
   license:
     name: "Verify License integrity"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 
@@ -38,7 +38,7 @@ jobs:
 
   build:
     name: "Build"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: |
       !contains(github.event.pull_request.title, '[ci skip]')
     steps:

--- a/.github/workflows/1.21_push.yml
+++ b/.github/workflows/1.21_push.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     name: "Build and Release"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: |
       !contains(github.event.head_commit.message, '[ci skip]')
     steps:


### PR DESCRIPTION
While waiting for the 1.21.1 release, I noticed the CI jobs were hanging. This is because GitHub [deprecated the ubuntu-20.04 runner image](https://github.com/actions/runner-images/issues/11101) on April 15, 2025.

As recommended by GitHub:

> Workflows using the `ubuntu-20.04` image label should be updated to `ubuntu-latest`, `ubuntu-22.04`, `ubuntu-24.04` .

I've updated the workflows to run on `ubuntu-24.04` to match what the 26.2 branch is currently using :)