### PR TITLE
Probably fix publishing to CurseForge

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -126,7 +126,7 @@ unifiedPublishing {
             curseforge {
                 token = CURSE_API_KEY
                 id = rootProject.curseforge_id
-                gameVersions.addAll "Java 25", project.minecraft_version
+                gameVersions.addAll "Java 25", "Client", "Server", project.minecraft_version
             }
         }
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -128,7 +128,7 @@ unifiedPublishing {
             curseforge {
                 token = CURSE_API_KEY
                 id = rootProject.curseforge_id
-                gameVersions.addAll "Java 25", project.minecraft_version
+                gameVersions.addAll "Java 25", "Client", "Server", project.minecraft_version
             }
         }
 


### PR DESCRIPTION
Don't know 100% whether this fixes the issue with the pipeline, but I am rather certain.
Should be backported to "LTS" releases as well (you mentioned that 1.21[.1] and 26.1 should be getting the fix from #729 as well).