### PR TITLE
docs: fix typo (Exmaple->Example (x1))

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example Mod: https://github.com/architectury/architectury-example-mod (a discont
 Mod Templates: https://github.com/architectury/architectury-templates (a set of templates to get started using the Architectury toolchain)
 
 ### Example: Usage of @ExpectPlatform
-![Exmaple of the @ExpectPlatform annotation, part of Architectury Injectables](https://camo.githubusercontent.com/78c68766affb70fbd88f9806e0e95f78765ec339448d7102065f2942be2b3215/68747470733a2f2f6d656469612e646973636f72646170702e6e65742f6174746163686d656e74732f3538363138363230323738313138383130382f3737363432383831343330393738353632302f756e6b6e6f776e2e706e673f77696474683d31313931266865696768743d343339)
+![Example of the @ExpectPlatform annotation, part of Architectury Injectables](https://camo.githubusercontent.com/78c68766affb70fbd88f9806e0e95f78765ec339448d7102065f2942be2b3215/68747470733a2f2f6d656469612e646973636f72646170702e6e65742f6174746163686d656e74732f3538363138363230323738313138383130382f3737363432383831343330393738353632302f756e6b6e6f776e2e706e673f77696474683d31313931266865696768743d343339)
 
 ### Credits
 


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues found in this project's documentation.

**Details:** Fix documentation typos: Exmaple->Example (x1)

**Files:**
- `README.md`

Documentation-only; no functional code changes.
